### PR TITLE
[FEAT]: Resolve disputes at the milestone level

### DIFF
--- a/contracts/engagement/src/contract.rs
+++ b/contracts/engagement/src/contract.rs
@@ -119,17 +119,21 @@ impl EngagementContract {
     // Disputes /////
     ////////////////////////
 
-    pub fn resolving_disputes(
+    pub fn resolving_milestone_disputes(
         e: Env,
         dispute_resolver: Address,
+        milestone_index: u32,
         client_funds: i128,
-        service_provider_funds: i128
+        service_provider_funds: i128,
+        trustless_work_address: Address
     ) -> Result<(), ContractError> {
-        DisputeManager::resolving_disputes(
+        DisputeManager::resolving_milestone_disputes(
             e,
             dispute_resolver,
+            milestone_index,
             client_funds,
-            service_provider_funds
+            service_provider_funds,
+            trustless_work_address
         )
     }
     

--- a/contracts/engagement/src/core/dispute.rs
+++ b/contracts/engagement/src/core/dispute.rs
@@ -10,11 +10,13 @@ pub struct DisputeManager;
 
 impl DisputeManager {
     
-    pub fn resolving_disputes(
+    pub fn resolving_milestone_disputes(
         e: Env,
         dispute_resolver: Address,
+        milestone_index: u32,
         client_funds: i128,
-        service_provider_funds: i128
+        service_provider_funds: i128,
+        trustless_work_address: Address
     ) -> Result<(), ContractError> {
         dispute_resolver.require_auth();
     

--- a/contracts/engagement/src/core/dispute.rs
+++ b/contracts/engagement/src/core/dispute.rs
@@ -46,7 +46,7 @@ impl DisputeManager {
         }
 
         let trustless_work_fee = (total_funds * 30) / 10000; // 0.3%
-        let platform_fee = (total_funds * (escrow.platform_fee as i128)) / 10000;
+        let platform_fee = (total_funds * escrow.platform_fee) / 10000;
         let total_fees = trustless_work_fee + platform_fee;
 
         let net_client_funds = client_funds - (client_funds * total_fees) / total_funds;

--- a/contracts/engagement/src/core/dispute.rs
+++ b/contracts/engagement/src/core/dispute.rs
@@ -1,7 +1,7 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{ Address, Env, String };
 use soroban_sdk::token::Client as TokenClient;
 
-use crate::storage::types::DataKey;
+use crate::storage::types::{DataKey, Milestone};
 use crate::error::ContractError;
 use crate::events::escrows_by_engagement_id;
 use crate::core::escrow::EscrowManager;
@@ -9,7 +9,7 @@ use crate::core::escrow::EscrowManager;
 pub struct DisputeManager;
 
 impl DisputeManager {
-    
+
     pub fn resolving_milestone_disputes(
         e: Env,
         dispute_resolver: Address,
@@ -19,71 +19,93 @@ impl DisputeManager {
         trustless_work_address: Address
     ) -> Result<(), ContractError> {
         dispute_resolver.require_auth();
-    
-        let escrow_result = EscrowManager::get_escrow(e.clone());
-        let escrow = match escrow_result {
-            Ok(esc) => esc,
-            Err(err) => return Err(err),
-        };
-    
-        if dispute_resolver != escrow.dispute_resolver {
-            return Err(ContractError::OnlyDisputeResolverCanExecuteThisFunction);
-        }
-    
-        if !escrow.dispute_flag {
-            return Err(ContractError::EscrowNotInDispute);
-        }
- 
-        let usdc_client = TokenClient::new(&e, &escrow.trustline);
-        let escrow_balance = usdc_client.balance(&e.current_contract_address());
 
-        let total_funds = client_funds + service_provider_funds;
-        if total_funds > escrow_balance {
-            return Err(ContractError::InsufficientFundsForResolution);
-        }
-    
-        if client_funds > 0 {
-            usdc_client.transfer(
-                &e.current_contract_address(),
-                &escrow.client,
-                &(client_funds as i128)
-            );
-        }
-
-        if service_provider_funds > 0 {
-            usdc_client.transfer(
-                &e.current_contract_address(),
-                &escrow.service_provider,
-                &(service_provider_funds as i128)
-            );
-        }
-    
-        e.storage().instance().set(&DataKey::Escrow, &escrow);
-    
-        escrows_by_engagement_id(&e, escrow.engagement_id.clone(), escrow);
-    
-        Ok(())
-    }
-
-    pub fn change_dispute_flag(
-        e: Env, 
-    ) -> Result<(), ContractError> {
-    
         let escrow_result = EscrowManager::get_escrow(e.clone());
         let mut escrow = match escrow_result {
             Ok(esc) => esc,
-            Err(err) => return Err(err),
+            Err(err) => {
+                return Err(err);
+            }
         };
-    
+
+        if dispute_resolver != escrow.dispute_resolver {
+            return Err(ContractError::OnlyDisputeResolverCanExecuteThisFunction);
+        }
+
+        let milestones = escrow.milestones.clone();
+        let milestone = match milestones.get(milestone_index) {
+            Some(m) => m,
+            None => {
+                return Err(ContractError::InvalidMileStoneIndex);
+            }
+        };
+
+        let total_funds = client_funds + service_provider_funds;
+        if total_funds != milestone.amount {
+            return Err(ContractError::InsufficientFundsForResolution);
+        }
+
+        let trustless_work_fee = (total_funds * 30) / 10000; // 0.3%
+        let platform_fee = (total_funds * (escrow.platform_fee as i128)) / 10000;
+        let total_fees = trustless_work_fee + platform_fee;
+
+        let net_client_funds = client_funds - (client_funds * total_fees) / total_funds;
+        let net_provider_funds =
+            service_provider_funds - (service_provider_funds * total_fees) / total_funds;
+
+        let usdc_client = TokenClient::new(&e, &escrow.trustline);
+        let contract_address = e.current_contract_address();
+
+        if trustless_work_fee > 0 {
+            usdc_client.transfer(&contract_address, &trustless_work_address, &trustless_work_fee);
+        }
+        if platform_fee > 0 {
+            usdc_client.transfer(&contract_address, &escrow.platform_address, &platform_fee);
+        }
+
+        if net_client_funds > 0 {
+            usdc_client.transfer(&contract_address, &escrow.client, &net_client_funds);
+        }
+        if net_provider_funds > 0 {
+            usdc_client.transfer(&contract_address, &escrow.service_provider, &net_provider_funds);
+        }
+
+        let mut updated_milestones = escrow.milestones.clone();
+
+        updated_milestones.set(
+            milestone_index,
+            Milestone {
+                status: String::from_str(&e, "resolved"),
+                ..milestone.clone()
+            }
+        );
+
+        escrow.milestones = updated_milestones;
+
+        e.storage().instance().set(&DataKey::Escrow, &escrow);
+        escrows_by_engagement_id(&e, escrow.engagement_id.clone(), escrow);
+
+        Ok(())
+    }
+
+    pub fn change_dispute_flag(e: Env) -> Result<(), ContractError> {
+        let escrow_result = EscrowManager::get_escrow(e.clone());
+        let mut escrow = match escrow_result {
+            Ok(esc) => esc,
+            Err(err) => {
+                return Err(err);
+            }
+        };
+
         if escrow.dispute_flag {
             return Err(ContractError::EscrowAlreadyInDispute);
         }
-    
+
         escrow.dispute_flag = true;
         e.storage().instance().set(&DataKey::Escrow, &escrow);
-    
+
         escrows_by_engagement_id(&e, escrow.engagement_id.clone(), escrow);
-    
+
         Ok(())
     }
 }

--- a/contracts/engagement/src/core/dispute.rs
+++ b/contracts/engagement/src/core/dispute.rs
@@ -40,6 +40,10 @@ impl DisputeManager {
             }
         };
 
+        if !milestone.dispute_flag {
+            return Err(ContractError::EscrowNotInDispute);
+        }
+
         let total_funds = client_funds + service_provider_funds;
         if total_funds != milestone.amount {
             return Err(ContractError::InsufficientFundsForResolution);

--- a/contracts/engagement/src/core/dispute.rs
+++ b/contracts/engagement/src/core/dispute.rs
@@ -41,7 +41,7 @@ impl DisputeManager {
         };
 
         if !milestone.dispute_flag {
-            return Err(ContractError::EscrowNotInDispute);
+            return Err(ContractError::MilestoneNotInDispute);
         }
 
         let total_funds = client_funds + service_provider_funds;

--- a/contracts/engagement/src/error.rs
+++ b/contracts/engagement/src/error.rs
@@ -35,6 +35,7 @@ pub enum ContractError {
     InvalidState = 29,
     EscrowOpenedForDisputeResolution = 30,
     AmountToDepositGreatherThanEscrowAmount = 31,
+    MilestoneNotInDispute = 32,
 
 }
 
@@ -72,6 +73,7 @@ impl fmt::Display for ContractError {
             ContractError::InvalidState => write!(f, "Invalid state"),
             ContractError::EscrowOpenedForDisputeResolution => write!(f, "Escrow has been opened for dispute resolution"),
             ContractError::AmountToDepositGreatherThanEscrowAmount => write!(f, "Amount to deposit is greater than the escrow amount"),
+            ContractError::MilestoneNotInDispute => write!(f, "Milestone not in dispute"),
         }
     }
 }

--- a/contracts/engagement/src/tests/test.rs
+++ b/contracts/engagement/src/tests/test.rs
@@ -2,11 +2,12 @@
 
 extern crate std;
 
-use crate::storage::types::{Escrow, Milestone};
-use crate::token::token::{Token, TokenClient};
+use crate::storage::types::{ Escrow, Milestone };
+use crate::token::token::{ Token, TokenClient };
 use crate::contract::EngagementContract;
 use crate::contract::EngagementContractClient;
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, IntoVal, String};
+use soroban_sdk::Vec;
+use soroban_sdk::{ testutils::Address as _, vec, Address, Env, IntoVal, String };
 
 fn create_usdc_token<'a>(e: &Env, admin: &Address) -> TokenClient<'a> {
     let token = TokenClient::new(e, &e.register_contract(None, Token {}));
@@ -44,7 +45,7 @@ fn test_initialize_excrow() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -99,7 +100,7 @@ fn test_change_escrow_properties() {
     let dispute_resolver_address = Address::generate(&env);
 
     let amount: i128 = 100_000_000;
-    let platform_fee = (0.3 * 10i128.pow(18) as f64) as i128;
+    let platform_fee = (0.3 * ((10i128).pow(18) as f64)) as i128;
 
     let initial_milestones = vec![
         &env,
@@ -118,7 +119,7 @@ fn test_change_escrow_properties() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -155,7 +156,7 @@ fn test_change_escrow_properties() {
     let new_release_signer = Address::generate(&env);
     let new_dispute_resolver = Address::generate(&env);
     let new_amount: i128 = 200_000_000;
-    let new_platform_fee = (0.5 * 10i128.pow(18) as f64) as i128;
+    let new_platform_fee = (0.5 * ((10i128).pow(18) as f64)) as i128;
 
     let new_milestones = vec![
         &env,
@@ -182,7 +183,7 @@ fn test_change_escrow_properties() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     // Test unauthorized access (should fail)
@@ -253,7 +254,7 @@ fn test_change_milestone_status_and_approved_flag() {
     let release_signer_address = Address::generate(&env);
     let dispute_resolver_address = Address::generate(&env);
     let amount: i128 = 100_000_000;
-    let platform_fee = (0.3 * 10i128.pow(18) as f64) as i128;
+    let platform_fee = (0.3 * ((10i128).pow(18) as f64)) as i128;
 
     let initial_milestones = vec![
         &env,
@@ -272,7 +273,7 @@ fn test_change_milestone_status_and_approved_flag() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -303,7 +304,7 @@ fn test_change_milestone_status_and_approved_flag() {
     engagement_client.change_milestone_status(
         &(0 as i128), // Milestone index
         &new_status,
-        &service_provider_address,
+        &service_provider_address
     );
 
     // Verify milestone status change
@@ -311,7 +312,7 @@ fn test_change_milestone_status_and_approved_flag() {
     assert_eq!(updated_escrow.milestones.get(0).unwrap().status, new_status);
 
     // Change milestone approved_flag (valid case)
-    engagement_client.change_milestone_flag( &(0 as i128), &true, &client_address);
+    engagement_client.change_milestone_flag(&(0 as i128), &true, &client_address);
 
     // Verify milestone approved_flag change
     let final_escrow = engagement_client.get_escrow();
@@ -325,7 +326,7 @@ fn test_change_milestone_status_and_approved_flag() {
     let result = engagement_client.try_change_milestone_status(
         &invalid_index,
         &new_status,
-        &service_provider_address,
+        &service_provider_address
     );
     assert!(result.is_err());
 
@@ -333,7 +334,7 @@ fn test_change_milestone_status_and_approved_flag() {
     let result = engagement_client.try_change_milestone_flag(
         &invalid_index,
         &true,
-        &client_address,
+        &client_address
     );
     assert!(result.is_err());
 
@@ -344,7 +345,7 @@ fn test_change_milestone_status_and_approved_flag() {
     let result = engagement_client.try_change_milestone_status(
         &(0 as i128),
         &new_status,
-        &unauthorized_address,
+        &unauthorized_address
     );
     assert!(result.is_err());
 
@@ -352,7 +353,7 @@ fn test_change_milestone_status_and_approved_flag() {
     let result = engagement_client.try_change_milestone_flag(
         &(0 as i128),
         &true,
-        &unauthorized_address,
+        &unauthorized_address
     );
     assert!(result.is_err());
 
@@ -378,16 +379,12 @@ fn test_change_milestone_status_and_approved_flag() {
     let result = engagement_client.try_change_milestone_status(
         &(0 as i128),
         &new_status,
-        &service_provider_address,
+        &service_provider_address
     );
     assert!(result.is_err());
 
     // Test for `change_approved_flag` on escrow with no milestones
-    let result = engagement_client.try_change_milestone_flag(
-        &(0 as i128),
-        &true,
-        &client_address,
-    );
+    let result = engagement_client.try_change_milestone_flag(&(0 as i128), &true, &client_address);
     assert!(result.is_err());
 }
 
@@ -428,7 +425,7 @@ fn test_distribute_escrow_earnings_successful_flow() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -454,17 +451,14 @@ fn test_distribute_escrow_earnings_successful_flow() {
     engagement_client.initialize_escrow(&escrow_properties);
 
     usdc_token.mint(&engagement_contract_address, &(amount as i128));
-    
-    engagement_client.distribute_escrow_earnings(
-        &release_signer_address,
-        &trustless_work_address,
-    );
+
+    engagement_client.distribute_escrow_earnings(&release_signer_address, &trustless_work_address);
 
     let total_amount = amount as i128;
     let trustless_work_commission = ((total_amount * 30) / 10000) as i128;
-    let platform_commission = (total_amount * platform_fee as i128) / 10000 as i128;
-    let service_provider_amount =
-        (total_amount - (trustless_work_commission + platform_commission)) as i128;
+    let platform_commission = (total_amount * (platform_fee as i128)) / (10000 as i128);
+    let service_provider_amount = (total_amount -
+        (trustless_work_commission + platform_commission)) as i128;
 
     assert_eq!(
         usdc_token.balance(&trustless_work_address),
@@ -535,12 +529,9 @@ fn test_distribute_escrow_earnings_no_milestones() {
     // Try to claim earnings with no milestones (should fail)
     let result = engagement_client.try_distribute_escrow_earnings(
         &release_signer_address,
-        &platform_address, 
+        &platform_address
     );
-    assert!(
-        result.is_err(),
-        "Should fail when no milestones are defined"
-    );
+    assert!(result.is_err(), "Should fail when no milestones are defined");
 }
 
 // Scenario 2: Milestones incomplete
@@ -562,17 +553,14 @@ fn test_distribute_escrow_earnings_milestones_incomplete() {
     let engagement_client = EngagementContractClient::new(&env, &engagement_contract_address);
 
     let engagement_id_incomplete = String::from_str(&env, "test_incomplete_milestones");
-    let milestones_incomplete = vec![
-        &env,
-        Milestone {
-            description: String::from_str(&env, "Incomplete milestone"),
-            status: String::from_str(&env, "Pending"),
-            approved_flag: false,
-            amount: 100_000,
-            dispute_flag: false,
-            release_flag: false,
-        },
-    ];
+    let milestones_incomplete = vec![&env, Milestone {
+        description: String::from_str(&env, "Incomplete milestone"),
+        status: String::from_str(&env, "Pending"),
+        approved_flag: false,
+        amount: 100_000,
+        dispute_flag: false,
+        release_flag: false,
+    }];
 
     let amount: i128 = 100_000_000;
     let platform_fee = 30;
@@ -598,14 +586,10 @@ fn test_distribute_escrow_earnings_milestones_incomplete() {
     // Try to claim earnings with incomplete milestones (should fail)
     let result = engagement_client.try_distribute_escrow_earnings(
         &release_signer_address,
-        &platform_address,
+        &platform_address
     );
-    assert!(
-        result.is_err(),
-        "Should fail when milestones are not completed"
-    );
+    assert!(result.is_err(), "Should fail when milestones are not completed");
 }
-
 
 #[test]
 fn test_dispute_flag_management() {
@@ -622,17 +606,14 @@ fn test_dispute_flag_management() {
     let amount: i128 = 100_000_000;
     let platform_fee = 30;
 
-    let milestones = vec![
-        &env,
-        Milestone {
-            description: String::from_str(&env, "First milestone"),
-            status: String::from_str(&env, "Pending"),
-            approved_flag: false,
-            amount: 100_000,
-            dispute_flag: false,
-            release_flag: false,
-        }
-    ];
+    let milestones = vec![&env, Milestone {
+        description: String::from_str(&env, "First milestone"),
+        status: String::from_str(&env, "Pending"),
+        approved_flag: false,
+        amount: 100_000,
+        dispute_flag: false,
+        release_flag: false,
+    }];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
     let engagement_client = EngagementContractClient::new(&env, &engagement_contract_address);
@@ -678,7 +659,6 @@ fn test_dispute_flag_management() {
     assert!(result.is_err());
 }
 
-
 #[test]
 fn test_dispute_resolution_process() {
     let env = Env::default();
@@ -690,6 +670,7 @@ fn test_dispute_resolution_process() {
     let platform_address = Address::generate(&env);
     let release_signer_address = Address::generate(&env);
     let dispute_resolver_address = Address::generate(&env);
+    let trustless_work_address = Address::generate(&env);
 
     let amount: i128 = 100_000_000;
     let platform_fee = 30;
@@ -697,6 +678,19 @@ fn test_dispute_resolution_process() {
     let engagement_contract_address = env.register_contract(None, EngagementContract);
     let engagement_client = EngagementContractClient::new(&env, &engagement_contract_address);
     let usdc_token = create_usdc_token(&env, &admin);
+
+    // Create milestone
+    let milestone = Milestone {
+        description: String::from_str(&env, "Test Milestone"),
+        status: String::from_str(&env, "in_progress"),
+        approved_flag: false,
+        amount: amount,
+        dispute_flag: false,
+        release_flag: false,
+    };
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(milestone);
 
     let engagement_id = String::from_str(&env, "test_resolution");
     let escrow_properties: Escrow = Escrow {
@@ -725,7 +719,7 @@ fn test_dispute_resolution_process() {
     assert_eq!(escrow_balance, amount as i128);
 
     // Change dispute approved_flag
-    engagement_client.change_dispute_flag( );
+    engagement_client.change_dispute_flag();
 
     // Verify approved_flag changed
     let disputed_escrow = engagement_client.get_escrow();
@@ -734,20 +728,36 @@ fn test_dispute_resolution_process() {
     // Resolve dispute
     let client_amount: i128 = 40_000_000;
     let provider_amount: i128 = 60_000_000;
+    let total_amount = client_amount + provider_amount;
 
-    engagement_client.resolving_disputes(
+    engagement_client.resolving_milestone_disputes(
         &dispute_resolver_address,
+        &0, // milestone_index
         &client_amount,
-        &provider_amount
+        &provider_amount,
+        &trustless_work_address
     );
 
-    // Verify final state
-    let final_escrow_balance = usdc_token.balance(&engagement_contract_address);
-    assert_eq!(final_escrow_balance, 0);
+    // Calculate expected fees
+    let expected_tw_fee = (total_amount * 30) / 10000; // 0.3%
+    let expected_platform_fee = (total_amount * platform_fee) / 10000;
 
-    // Verify token balances
-    assert_eq!(usdc_token.balance(&client_address), client_amount as i128);
-    assert_eq!(usdc_token.balance(&service_provider_address), provider_amount as i128);
+    // Calculate expected amounts after fees
+    let expected_client = client_amount - (client_amount * (expected_tw_fee + expected_platform_fee)) / total_amount;
+    let expected_provider = provider_amount - (provider_amount * (expected_tw_fee + expected_platform_fee)) / total_amount;
+
+    // Verify balances
+    assert_eq!(usdc_token.balance(&engagement_contract_address), 0);
+    assert_eq!(usdc_token.balance(&trustless_work_address), expected_tw_fee);
+    assert_eq!(usdc_token.balance(&platform_address), expected_platform_fee);
+    assert_eq!(usdc_token.balance(&client_address), expected_client);
+    assert_eq!(usdc_token.balance(&service_provider_address), expected_provider);
+
+    // Verify milestone status
+    let final_escrow = engagement_client.get_escrow();
+    let resolved_milestone = final_escrow.milestones.get(0).unwrap();
+    assert_eq!(resolved_milestone.status, String::from_str(&env, "resolved"));
+
 }
 
 #[test]
@@ -780,7 +790,7 @@ fn test_fund_escrow_successful_deposit() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -811,10 +821,7 @@ fn test_fund_escrow_successful_deposit() {
 
     let amount_to_deposit: i128 = 100_000;
 
-    engagement_client.fund_escrow(
-        &release_signer_address, 
-        &amount_to_deposit
-    );
+    engagement_client.fund_escrow(&release_signer_address, &amount_to_deposit);
 
     let expected_result_amount: i128 = 100_100_000;
 
@@ -855,7 +862,7 @@ fn test_fund_escrow_fully_funded_error() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -881,21 +888,15 @@ fn test_fund_escrow_fully_funded_error() {
 
     engagement_client.initialize_escrow(&escrow_properties);
 
-    let funded_amount: i128 = 100_000_000; 
+    let funded_amount: i128 = 100_000_000;
     usdc_token.mint(&engagement_contract_address, &(funded_amount as i128));
     usdc_token.mint(&release_signer_address, &(amount as i128));
 
     let amount_to_deposit: i128 = 100_000;
 
-    let result = engagement_client.try_fund_escrow(
-        &release_signer_address, 
-        &amount_to_deposit
-    );
+    let result = engagement_client.try_fund_escrow(&release_signer_address, &amount_to_deposit);
 
-    assert!(
-        result.is_err(),
-        "Should fail when the escrow is fully funded"
-    );
+    assert!(result.is_err(), "Should fail when the escrow is fully funded");
 }
 
 #[test]
@@ -928,7 +929,7 @@ fn test_fund_escrow_signer_insufficient_funds_error() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -956,22 +957,15 @@ fn test_fund_escrow_signer_insufficient_funds_error() {
 
     usdc_token.mint(&engagement_contract_address, &(amount as i128));
 
-    let signer_funds: i128 = 100_000; 
+    let signer_funds: i128 = 100_000;
     usdc_token.mint(&release_signer_address, &(signer_funds as i128));
 
     let amount_to_deposit: i128 = 180_000;
 
-    let result = engagement_client.try_fund_escrow(
-        &release_signer_address, 
-        &amount_to_deposit
-    );
+    let result = engagement_client.try_fund_escrow(&release_signer_address, &amount_to_deposit);
 
-    assert!(
-        result.is_err(),
-        "Should fail when the signer has insufficient funds"
-    );
+    assert!(result.is_err(), "Should fail when the signer has insufficient funds");
 }
-
 
 #[test]
 fn test_fund_escrow_dispute_flag_error() {
@@ -1003,7 +997,7 @@ fn test_fund_escrow_dispute_flag_error() {
             amount: 100_000,
             dispute_flag: false,
             release_flag: false,
-        },
+        }
     ];
 
     let engagement_contract_address = env.register_contract(None, EngagementContract);
@@ -1032,13 +1026,7 @@ fn test_fund_escrow_dispute_flag_error() {
 
     let amount_to_deposit: i128 = 80_000;
 
-    let result = engagement_client.try_fund_escrow(
-        &release_signer_address, 
-        &amount_to_deposit
-    );
+    let result = engagement_client.try_fund_escrow(&release_signer_address, &amount_to_deposit);
 
-    assert!(
-        result.is_err(),
-        "Should fail when the dispute approved_flag is true"
-    );
+    assert!(result.is_err(), "Should fail when the dispute approved_flag is true");
 }

--- a/contracts/engagement/src/tests/test.rs
+++ b/contracts/engagement/src/tests/test.rs
@@ -702,7 +702,7 @@ fn test_dispute_resolution_process() {
         platform_address: platform_address.clone(),
         amount: amount,
         platform_fee: platform_fee,
-        milestones: vec![&env],
+        milestones: milestones,
         release_signer: release_signer_address.clone(),
         dispute_resolver: dispute_resolver_address.clone(),
         dispute_flag: false,
@@ -738,22 +738,18 @@ fn test_dispute_resolution_process() {
         &trustless_work_address
     );
 
-    // Calculate expected fees
     let expected_tw_fee = (total_amount * 30) / 10000; // 0.3%
     let expected_platform_fee = (total_amount * platform_fee) / 10000;
 
-    // Calculate expected amounts after fees
     let expected_client = client_amount - (client_amount * (expected_tw_fee + expected_platform_fee)) / total_amount;
     let expected_provider = provider_amount - (provider_amount * (expected_tw_fee + expected_platform_fee)) / total_amount;
 
-    // Verify balances
     assert_eq!(usdc_token.balance(&engagement_contract_address), 0);
     assert_eq!(usdc_token.balance(&trustless_work_address), expected_tw_fee);
     assert_eq!(usdc_token.balance(&platform_address), expected_platform_fee);
     assert_eq!(usdc_token.balance(&client_address), expected_client);
     assert_eq!(usdc_token.balance(&service_provider_address), expected_provider);
 
-    // Verify milestone status
     let final_escrow = engagement_client.get_escrow();
     let resolved_milestone = final_escrow.milestones.get(0).unwrap();
     assert_eq!(resolved_milestone.status, String::from_str(&env, "resolved"));

--- a/contracts/engagement/src/tests/test.rs
+++ b/contracts/engagement/src/tests/test.rs
@@ -685,7 +685,7 @@ fn test_dispute_resolution_process() {
         status: String::from_str(&env, "in_progress"),
         approved_flag: false,
         amount: amount,
-        dispute_flag: false,
+        dispute_flag: true,
         release_flag: false,
     };
 

--- a/contracts/engagement/test_snapshots/tests/test/test_dispute_resolution_process.1.json
+++ b/contracts/engagement/test_snapshots/tests/test/test_dispute_resolution_process.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 8,
+    "address": 9,
     "nonce": 0
   },
   "auth": [
@@ -12,7 +12,7 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
               "function_name": "mint",
               "args": [
                 {
@@ -37,14 +37,14 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
               "function_name": "transfer",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
                 },
                 {
                   "i128": {
@@ -68,11 +68,14 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
-              "function_name": "resolving_disputes",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+              "function_name": "resolving_milestone_disputes",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "u32": 0
                 },
                 {
                   "i128": {
@@ -85,6 +88,9 @@
                     "hi": 0,
                     "lo": 60000000
                   }
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 }
               ]
             }
@@ -93,6 +99,9 @@
         }
       ]
     ],
+    [],
+    [],
+    [],
     [],
     [],
     []
@@ -209,7 +218,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -220,7 +229,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -295,7 +304,63 @@
                                 "symbol": "milestones"
                               },
                               "val": {
-                                "vec": []
+                                "vec": [
+                                  {
+                                    "map": [
+                                      {
+                                        "key": {
+                                          "symbol": "amount"
+                                        },
+                                        "val": {
+                                          "i128": {
+                                            "hi": 0,
+                                            "lo": 100000000
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "approved_flag"
+                                        },
+                                        "val": {
+                                          "bool": false
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "description"
+                                        },
+                                        "val": {
+                                          "string": "Test Milestone"
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "dispute_flag"
+                                        },
+                                        "val": {
+                                          "bool": false
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "release_flag"
+                                        },
+                                        "val": {
+                                          "bool": false
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "status"
+                                        },
+                                        "val": {
+                                          "string": "resolved"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             },
                             {
@@ -346,7 +411,7 @@
                                 "symbol": "trustline"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                               }
                             }
                           ]
@@ -365,7 +430,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
             "key": {
               "vec": [
                 {
@@ -385,7 +450,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
                 "key": {
                   "vec": [
                     {
@@ -400,7 +465,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 40000000
+                    "lo": 39760000
                   }
                 }
               }
@@ -413,7 +478,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
             "key": {
               "vec": [
                 {
@@ -433,7 +498,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
                 "key": {
                   "vec": [
                     {
@@ -461,7 +526,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
             "key": {
               "vec": [
                 {
@@ -481,7 +546,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
                 "key": {
                   "vec": [
                     {
@@ -496,7 +561,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 60000000
+                    "lo": 59640000
                   }
                 }
               }
@@ -509,7 +574,55 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
             "key": {
               "vec": [
                 {
@@ -529,7 +642,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
                 "key": {
                   "vec": [
                     {
@@ -537,6 +650,54 @@
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
                     }
                   ]
                 },
@@ -557,7 +718,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -568,7 +729,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -668,7 +829,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "initialize"
@@ -698,7 +859,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -728,7 +889,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000007"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
               },
               {
                 "symbol": "initialize_escrow"
@@ -792,7 +953,63 @@
                     "symbol": "milestones"
                   },
                   "val": {
-                    "vec": []
+                    "vec": [
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 100000000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "approved_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "string": "Test Milestone"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "dispute_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "release_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "string": "in_progress"
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
@@ -843,7 +1060,7 @@
                     "symbol": "trustline"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                   }
                 }
               ]
@@ -856,7 +1073,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -926,7 +1143,63 @@
                     "symbol": "milestones"
                   },
                   "val": {
-                    "vec": []
+                    "vec": [
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 100000000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "approved_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "string": "Test Milestone"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "dispute_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "release_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "string": "in_progress"
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
@@ -977,7 +1250,7 @@
                     "symbol": "trustline"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                   }
                 }
               ]
@@ -999,7 +1272,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "mint"
@@ -1026,7 +1299,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "contract",
         "body": {
           "v0": {
@@ -1055,7 +1328,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1085,7 +1358,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "transfer"
@@ -1097,7 +1370,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
                 },
                 {
                   "i128": {
@@ -1115,7 +1388,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "contract",
         "body": {
           "v0": {
@@ -1127,7 +1400,7 @@
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
               }
             ],
             "data": {
@@ -1144,7 +1417,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1174,14 +1447,14 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "balance"
               }
             ],
             "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
             }
           }
         }
@@ -1191,7 +1464,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1226,7 +1499,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000007"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
               },
               {
                 "symbol": "change_dispute_flag"
@@ -1241,7 +1514,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "contract",
         "body": {
           "v0": {
@@ -1313,7 +1586,63 @@
                         "symbol": "milestones"
                       },
                       "val": {
-                        "vec": []
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 100000000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "approved_flag"
+                                },
+                                "val": {
+                                  "bool": false
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "string": "Test Milestone"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "dispute_flag"
+                                },
+                                "val": {
+                                  "bool": false
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "release_flag"
+                                },
+                                "val": {
+                                  "bool": false
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "string": "in_progress"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     },
                     {
@@ -1364,7 +1693,7 @@
                         "symbol": "trustline"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                       }
                     }
                   ]
@@ -1379,7 +1708,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1409,7 +1738,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000007"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
               },
               {
                 "symbol": "get_escrow"
@@ -1424,7 +1753,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1494,7 +1823,63 @@
                     "symbol": "milestones"
                   },
                   "val": {
-                    "vec": []
+                    "vec": [
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 100000000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "approved_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "string": "Test Milestone"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "dispute_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "release_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "string": "in_progress"
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
@@ -1545,7 +1930,7 @@
                     "symbol": "trustline"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                   }
                 }
               ]
@@ -1567,10 +1952,10 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000007"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
               },
               {
-                "symbol": "resolving_disputes"
+                "symbol": "resolving_milestone_disputes"
               }
             ],
             "data": {
@@ -1579,6 +1964,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
+                  "u32": 0
+                },
+                {
                   "i128": {
                     "hi": 0,
                     "lo": 40000000
@@ -1589,34 +1977,11 @@
                     "hi": 0,
                     "lo": 60000000
                   }
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 }
               ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
-              },
-              {
-                "symbol": "balance"
-              }
-            ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
             }
           }
         }
@@ -1632,36 +1997,10 @@
           "v0": {
             "topics": [
               {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "balance"
-              }
-            ],
-            "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 100000000
-              }
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "transfer"
@@ -1670,15 +2009,15 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 40000000
+                    "lo": 300000
                   }
                 }
               ]
@@ -1691,7 +2030,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "contract",
         "body": {
           "v0": {
@@ -1700,7 +2039,185 @@
                 "symbol": "transfer"
               },
               {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+              },
+              {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 300000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 300000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 39760000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
               },
               {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
@@ -1709,7 +2226,7 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 40000000
+                "lo": 39760000
               }
             }
           }
@@ -1720,7 +2237,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1741,7 +2258,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1750,7 +2267,7 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "transfer"
@@ -1759,7 +2276,7 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -1767,7 +2284,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 60000000
+                    "lo": 59640000
                   }
                 }
               ]
@@ -1780,7 +2297,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "contract",
         "body": {
           "v0": {
@@ -1789,7 +2306,7 @@
                 "symbol": "transfer"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
               },
               {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -1798,7 +2315,7 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 60000000
+                "lo": 59640000
               }
             }
           }
@@ -1809,7 +2326,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1830,7 +2347,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "contract",
         "body": {
           "v0": {
@@ -1902,7 +2419,63 @@
                         "symbol": "milestones"
                       },
                       "val": {
-                        "vec": []
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 100000000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "approved_flag"
+                                },
+                                "val": {
+                                  "bool": false
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "string": "Test Milestone"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "dispute_flag"
+                                },
+                                "val": {
+                                  "bool": false
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "release_flag"
+                                },
+                                "val": {
+                                  "bool": false
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "string": "resolved"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     },
                     {
@@ -1953,7 +2526,7 @@
                         "symbol": "trustline"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                       }
                     }
                   ]
@@ -1968,7 +2541,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000007",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -1977,7 +2550,7 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "resolving_disputes"
+                "symbol": "resolving_milestone_disputes"
               }
             ],
             "data": "void"
@@ -1998,14 +2571,14 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "balance"
               }
             ],
             "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
             }
           }
         }
@@ -2015,7 +2588,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -2050,7 +2623,111 @@
                 "symbol": "fn_call"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 300000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 300000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
               },
               {
                 "symbol": "balance"
@@ -2067,7 +2744,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000008",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -2082,7 +2759,59 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 40000000
+                "lo": 39760000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000009"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000009",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 59640000
               }
             }
           }
@@ -2105,12 +2834,10 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000008"
               },
               {
-                "symbol": "balance"
+                "symbol": "get_escrow"
               }
             ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-            }
+            "data": "void"
           }
         }
       },
@@ -2128,14 +2855,178 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "get_escrow"
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 60000000
-              }
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100000000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "client"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Test Escrow Description"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "dispute_flag"
+                  },
+                  "val": {
+                    "bool": true
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "dispute_resolver"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "engagement_id"
+                  },
+                  "val": {
+                    "string": "test_resolution"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "milestones"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 100000000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "approved_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "string": "Test Milestone"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "dispute_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "release_flag"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "string": "resolved"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "platform_address"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "platform_fee"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 30
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "release_signer"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "service_provider"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Test Escrow"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "trustline"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                  }
+                }
+              ]
             }
           }
         }


### PR DESCRIPTION
<p align="center"> <img src="https://github.com/user-attachments/assets/5b182044-dceb-41f5-acf0-da22dea7c98a" alt="CLR-S (2)"> </p>

# Pull Request | Trustless Work

## 1. Issue Link

<!-- Provide the link to the related issue here -->

- Closes #35 

---

## 2. Brief Description of the Issue

Modify the dispute resolution function to work at milestone level instead of escrow level, allowing partial dispute resolution.

---

## 3. Changes Made

- Renamed `resolving_disputes` to `resolving_milestone_disputes`
- Added milestone index parameter for specific milestone targeting
- Implemented fee calculation and distribution (0.3% Trustless Work + platform fee)
- Added milestone-specific validations
- Updated tests to verify fees and milestone status resolution
- Fixed milestone array handling in test setup

---

## 4. Evidence After Solution

<img width="694" alt="image" src="https://github.com/user-attachments/assets/936b1d7f-d6c3-46a8-a93b-ffe4166e5fac" />


---

## 5. Important Notes

- The function now requires `trustless_work_address` parameter
- Fees are proportionally deducted from both client and provider funds
- Only the specified milestone is marked as resolved
- All tests passing including fee calculations and status updates
