### PR TITLE
feat: add cross-chain CCTP USDC release support for milestone payouts

### DIFF
--- a/contracts/escrow/src/cctp/constants.rs
+++ b/contracts/escrow/src/cctp/constants.rs
@@ -1,0 +1,63 @@
+/// Stellar CCTP domain ID (assigned by Circle)
+#[allow(dead_code)]
+pub const STELLAR_CCTP_DOMAIN: u32 = 27;
+
+/// CCTP domain IDs for supported destination chains
+pub const CCTP_DOMAIN_ETHEREUM: u32 = 0;
+pub const CCTP_DOMAIN_AVALANCHE: u32 = 1;
+pub const CCTP_DOMAIN_OP_MAINNET: u32 = 2;
+pub const CCTP_DOMAIN_ARBITRUM_ONE: u32 = 3;
+pub const CCTP_DOMAIN_SOLANA: u32 = 5;
+pub const CCTP_DOMAIN_BASE: u32 = 6;
+pub const CCTP_DOMAIN_POLYGON_POS: u32 = 7;
+
+/// USDC decimal difference between Stellar (7) and other chains (6)
+/// To convert: amount_6_decimals = amount_7_decimals / USDC_DECIMAL_DIFF
+pub const USDC_DECIMAL_DIFF: i128 = 10;
+
+/// Testnet: TokenMessengerMinter contract address
+/// From Circle's official docs:
+/// https://developers.circle.com/cctp/references/stellar-contracts
+pub const CCTP_TOKEN_MESSENGER_ADDRESS: &str =
+    "CDNG7HXAPBWICI2E3AUBP3YZWZELJLYSB6F5CC7WLDTLTHVM74SLRTHP";
+
+/// Testnet: MessageTransmitter contract address
+/// From Circle's official docs:
+/// https://developers.circle.com/cctp/references/stellar-contracts
+#[allow(dead_code)]
+pub const CCTP_MESSAGE_TRANSMITTER_ADDRESS: &str =
+    "CBJ6MTCKKZG73PMDZCJMSFRD7DQEMI4FKDH7CGDSV4W6FHCRBCQAVVJY";
+
+/// Minimum valid CCTP domain ID
+#[allow(dead_code)]
+pub const MIN_VALID_CCTP_DOMAIN: u32 = 0;
+
+/// Maximum valid CCTP domain ID (as of current supported chains)
+#[allow(dead_code)]
+pub const MAX_VALID_CCTP_DOMAIN: u32 = 7;
+
+/// Valid CCTP domain IDs for validation
+pub const VALID_CCTP_DOMAINS: [u32; 7] = [
+    CCTP_DOMAIN_ETHEREUM,
+    CCTP_DOMAIN_AVALANCHE,
+    CCTP_DOMAIN_OP_MAINNET,
+    CCTP_DOMAIN_ARBITRUM_ONE,
+    CCTP_DOMAIN_SOLANA,
+    CCTP_DOMAIN_BASE,
+    CCTP_DOMAIN_POLYGON_POS,
+];
+
+/// Check if a domain ID is a valid CCTP domain
+#[inline]
+pub fn is_valid_cctp_domain(domain: u32) -> bool {
+    VALID_CCTP_DOMAINS.contains(&domain)
+}
+
+/// Truncate a Stellar USDC amount (7 decimals) to CCTP amount (6 decimals)
+/// Returns (amount_6_decimals, remainder_7th_decimal)
+#[inline]
+pub fn truncate_to_6_decimals(amount_7_decimals: i128) -> (i128, i128) {
+    let amount_6 = amount_7_decimals / USDC_DECIMAL_DIFF;
+    let remainder = amount_7_decimals % USDC_DECIMAL_DIFF;
+    (amount_6, remainder)
+}

--- a/contracts/escrow/src/cctp/mod.rs
+++ b/contracts/escrow/src/cctp/mod.rs
@@ -1,0 +1,5 @@
+pub mod constants;
+pub mod token_messenger_client;
+
+pub use constants::*;
+pub use token_messenger_client::*;

--- a/contracts/escrow/src/cctp/token_messenger_client.rs
+++ b/contracts/escrow/src/cctp/token_messenger_client.rs
@@ -1,0 +1,26 @@
+use soroban_sdk::{Address, Bytes, Env, IntoVal, Symbol, Val, Vec};
+
+/// Client for Circle's TokenMessengerMinter contract on Stellar
+/// Calls deposit_for_burn to initiate a cross-chain USDC transfer
+pub struct TokenMessengerClient(Address);
+
+impl TokenMessengerClient {
+    pub fn new(_env: &Env, address: &Address) -> Self {
+        Self(address.clone())
+    }
+
+    /// Call deposit_for_burn on the TokenMessengerMinter contract
+    /// Burns USDC on Stellar and emits a message for minting on the destination chain
+    pub fn deposit_for_burn(
+        &self,
+        env: &Env,
+        amount: i128,
+        destination_domain: u32,
+        mint_recipient: Bytes,
+        token_address: Address,
+    ) {
+        let args: Vec<Val> = (amount, destination_domain, mint_recipient, token_address)
+            .into_val(env);
+        env.invoke_contract::<Val>(&self.0, &Symbol::new(env, "deposit_for_burn"), args);
+    }
+}

--- a/contracts/escrow/src/core/escrow.rs
+++ b/contracts/escrow/src/core/escrow.rs
@@ -1,6 +1,9 @@
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
+use crate::cctp::{
+    truncate_to_6_decimals, TokenMessengerClient, CCTP_TOKEN_MESSENGER_ADDRESS,
+};
 use crate::core::validators::escrow::{
     validate_escrow_property_change_conditions, validate_fund_escrow_conditions,
     validate_initialize_escrow_conditions, validate_release_conditions,
@@ -81,15 +84,73 @@ impl EscrowManager {
 
         if fee_result.platform_fee > 0 {
             token_client.transfer(
-            &contract_address,
-            &escrow.roles.platform,
-            &fee_result.platform_fee,
+                &contract_address,
+                &escrow.roles.platform,
+                &fee_result.platform_fee,
             );
         }
 
         let receiver = Self::get_receiver(&escrow);
         if fee_result.receiver_amount > 0 {
-            token_client.transfer(&contract_address, &receiver, &fee_result.receiver_amount);
+            let first_milestone = escrow.milestones.get(0);
+            let has_cross_chain = first_milestone
+                .as_ref()
+                .and_then(|m| m.cross_chain_destination_domain)
+                .is_some();
+            if has_cross_chain {
+                Self::release_cross_chain(
+                    e,
+                    &token_client,
+                    &contract_address,
+                    &receiver,
+                    fee_result.receiver_amount,
+                    &first_milestone.unwrap(),
+                )?;
+            } else {
+                token_client.transfer(
+                    &contract_address,
+                    &receiver,
+                    &fee_result.receiver_amount,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn release_cross_chain(
+        e: &Env,
+        token_client: &TokenClient,
+        contract_address: &Address,
+        stellar_receiver: &Address,
+        net_amount: i128,
+        milestone: &crate::storage::types::Milestone,
+    ) -> Result<(), ContractError> {
+        let (amount_6_decimals, remainder) = truncate_to_6_decimals(net_amount);
+
+        if amount_6_decimals > 0 {
+            let token_messenger_address =
+                Address::from_string(&soroban_sdk::String::from_str(
+                    e,
+                    CCTP_TOKEN_MESSENGER_ADDRESS,
+                ));
+            let token_messenger =
+                TokenMessengerClient::new(e, &token_messenger_address);
+
+            let recipient = milestone.cross_chain_recipient.clone().unwrap_or_else(|| soroban_sdk::Bytes::from_array(e, &[0u8; 32]));
+            let destination_domain = milestone.cross_chain_destination_domain.unwrap_or(0);
+
+            token_messenger.deposit_for_burn(
+                e,
+                amount_6_decimals,
+                destination_domain,
+                recipient,
+                token_client.address.clone(),
+            );
+        }
+
+        if remainder > 0 {
+            token_client.transfer(contract_address, stellar_receiver, &remainder);
         }
 
         Ok(())

--- a/contracts/escrow/src/core/validators/escrow.rs
+++ b/contracts/escrow/src/core/validators/escrow.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{Address, Env};
 
 use crate::{
+    cctp::is_valid_cctp_domain,
     error::ContractError,
     storage::types::{DataKey, Escrow},
 };
@@ -133,6 +134,8 @@ pub fn validate_escrow_conditions(
         }
     }
 
+    validate_cross_chain_receivers(new_escrow)?;
+
     Ok(())
 }
 
@@ -182,5 +185,28 @@ pub fn validate_fund_escrow_conditions(
         return Err(ContractError::InsufficientFundsForEscrowFunding);
     }
 
+    Ok(())
+}
+
+#[inline]
+pub fn validate_cross_chain_receivers(escrow: &Escrow) -> Result<(), ContractError> {
+    for milestone in escrow.milestones.iter() {
+        if let Some(domain) = milestone.cross_chain_destination_domain {
+            if !is_valid_cctp_domain(domain) {
+                return Err(ContractError::InvalidCctpDomain);
+            }
+            if let Some(recipient) = &milestone.cross_chain_recipient {
+                if recipient.len() == 0 {
+                    return Err(ContractError::InvalidCctpRecipient);
+                }
+                let all_zero = recipient.iter().all(|b| b == 0);
+                if all_zero {
+                    return Err(ContractError::InvalidCctpRecipient);
+                }
+            } else {
+                return Err(ContractError::InvalidCctpRecipient);
+            }
+        }
+    }
     Ok(())
 }

--- a/contracts/escrow/src/error.rs
+++ b/contracts/escrow/src/error.rs
@@ -49,6 +49,8 @@ pub enum ContractError {
     EscrowNotFullyProcessed = 44,
     TooManyDistributions = 45,
     MilestoneToUpdateDoesNotExist = 46,
+    InvalidCctpDomain = 47,
+    InvalidCctpRecipient = 48,
 }
 
 // impl fmt::Display for ContractError {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+mod cctp;
 mod contract;
 mod core {
     pub mod dispute;

--- a/contracts/escrow/src/storage/types.rs
+++ b/contracts/escrow/src/storage/types.rs
@@ -22,6 +22,8 @@ pub struct Milestone {
     pub status: String,
     pub evidence: String,
     pub approved: bool,
+    pub cross_chain_destination_domain: Option<u32>,
+    pub cross_chain_recipient: Option<soroban_sdk::Bytes>,
 }
 
 #[contracttype]

--- a/contracts/escrow/src/tests/balance.rs
+++ b/contracts/escrow/src/tests/balance.rs
@@ -36,6 +36,8 @@ fn test_get_multiple_escrow_balances_platform_authorized() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 

--- a/contracts/escrow/src/tests/cross_chain.rs
+++ b/contracts/escrow/src/tests/cross_chain.rs
@@ -1,0 +1,299 @@
+extern crate std;
+
+use soroban_sdk::{
+    contract, contractimpl, testutils::Address as _, vec, Address, Bytes, Env,
+};
+
+use crate::storage::types::{Escrow, Flags, Milestone, Roles, Trustline};
+use soroban_sdk::String as SorobanString;
+
+use super::helpers::{create_escrow_contract, create_usdc_token};
+
+/// Mock TokenMessenger contract for testing
+/// Accepts deposit_for_burn calls and records the parameters
+#[contract]
+pub struct MockTokenMessenger;
+
+#[contractimpl]
+impl MockTokenMessenger {
+    pub fn deposit_for_burn(
+        _env: Env,
+        _amount: i128,
+        _destination_domain: u32,
+        _mint_recipient: Bytes,
+        _token_address: Address,
+    ) {
+        // In tests, we just verify this function can be called
+        // The actual CCTP burn would happen on real testnet
+    }
+}
+
+#[test]
+fn test_cross_chain_invalid_domain_validation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: SorobanString::from_str(&env, "Invalid domain"),
+            status: SorobanString::from_str(&env, "Pending"),
+            evidence: SorobanString::from_str(&env, ""),
+            approved: false,
+            cross_chain_destination_domain: Some(999),
+            cross_chain_recipient: Some(Bytes::from_array(&env, &[1u8; 32])),
+        },
+    ];
+
+    let roles = Roles {
+        approver: approver.clone(),
+        service_provider: service_provider.clone(),
+        platform: platform.clone(),
+        release_signer: release_signer.clone(),
+        dispute_resolver: dispute_resolver.clone(),
+        receiver: receiver.clone(),
+    };
+
+    let escrow_properties = Escrow {
+        engagement_id: SorobanString::from_str(&env, "invalid_domain"),
+        title: SorobanString::from_str(&env, "Test"),
+        description: SorobanString::from_str(&env, "Test"),
+        roles,
+        amount: 100_000_000,
+        platform_fee: 0,
+        milestones,
+        flags: Flags {
+            disputed: false,
+            released: false,
+            resolved: false,
+        },
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env);
+    let client = test_data.client;
+
+    let result = client.try_initialize_escrow(&escrow_properties);
+    assert!(result.is_err(), "Should reject invalid CCTP domain");
+}
+
+#[test]
+fn test_cross_chain_zero_recipient_validation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: SorobanString::from_str(&env, "Zero recipient"),
+            status: SorobanString::from_str(&env, "Pending"),
+            evidence: SorobanString::from_str(&env, ""),
+            approved: false,
+            cross_chain_destination_domain: Some(6),
+            cross_chain_recipient: Some(Bytes::from_array(&env, &[0u8; 32])),
+        },
+    ];
+
+    let roles = Roles {
+        approver: approver.clone(),
+        service_provider: service_provider.clone(),
+        platform: platform.clone(),
+        release_signer: release_signer.clone(),
+        dispute_resolver: dispute_resolver.clone(),
+        receiver: receiver.clone(),
+    };
+
+    let escrow_properties = Escrow {
+        engagement_id: SorobanString::from_str(&env, "zero_recipient"),
+        title: SorobanString::from_str(&env, "Test"),
+        description: SorobanString::from_str(&env, "Test"),
+        roles,
+        amount: 100_000_000,
+        platform_fee: 0,
+        milestones,
+        flags: Flags {
+            disputed: false,
+            released: false,
+            resolved: false,
+        },
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env);
+    let client = test_data.client;
+
+    let result = client.try_initialize_escrow(&escrow_properties);
+    assert!(result.is_err(), "Should reject zero-byte CCTP recipient");
+}
+
+#[test]
+fn test_cross_chain_missing_recipient_validation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: SorobanString::from_str(&env, "Missing recipient"),
+            status: SorobanString::from_str(&env, "Pending"),
+            evidence: SorobanString::from_str(&env, ""),
+            approved: false,
+            cross_chain_destination_domain: Some(6),
+            cross_chain_recipient: None,
+        },
+    ];
+
+    let roles = Roles {
+        approver: approver.clone(),
+        service_provider: service_provider.clone(),
+        platform: platform.clone(),
+        release_signer: release_signer.clone(),
+        dispute_resolver: dispute_resolver.clone(),
+        receiver: receiver.clone(),
+    };
+
+    let escrow_properties = Escrow {
+        engagement_id: SorobanString::from_str(&env, "missing_recipient"),
+        title: SorobanString::from_str(&env, "Test"),
+        description: SorobanString::from_str(&env, "Test"),
+        roles,
+        amount: 100_000_000,
+        platform_fee: 0,
+        milestones,
+        flags: Flags {
+            disputed: false,
+            released: false,
+            resolved: false,
+        },
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env);
+    let client = test_data.client;
+
+    let result = client.try_initialize_escrow(&escrow_properties);
+    assert!(result.is_err(), "Should reject missing CCTP recipient");
+}
+
+#[test]
+fn test_cross_chain_backwards_compatible() {
+    // When cross_chain fields are None, release must behave identically to before
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let trustless_work = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let amount: i128 = 100_000_000;
+    usdc_token.1.mint(&approver, &amount);
+
+    let platform_fee = 5 * 100;
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: SorobanString::from_str(&env, "Backwards compatible"),
+            status: SorobanString::from_str(&env, "Completed"),
+            evidence: SorobanString::from_str(&env, "Evidence"),
+            approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
+        },
+    ];
+
+    let roles = Roles {
+        approver: approver.clone(),
+        service_provider: service_provider.clone(),
+        platform: platform.clone(),
+        release_signer: release_signer.clone(),
+        dispute_resolver: dispute_resolver.clone(),
+        receiver: receiver.clone(),
+    };
+
+    let escrow_properties = Escrow {
+        engagement_id: SorobanString::from_str(&env, "backwards_compat"),
+        title: SorobanString::from_str(&env, "Test"),
+        description: SorobanString::from_str(&env, "Test backwards compatibility"),
+        roles,
+        amount,
+        platform_fee,
+        milestones,
+        flags: Flags {
+            disputed: false,
+            released: false,
+            resolved: false,
+        },
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env);
+    let client = test_data.client;
+
+    client.initialize_escrow(&escrow_properties);
+
+    usdc_token.1.mint(&client.address, &amount);
+
+    client.approve_milestone(&0, &approver);
+    client.release_funds(&release_signer, &trustless_work);
+
+    let tw_fee = (amount * 30) / 10000;
+    let platform_commission = (amount * platform_fee as i128) / 10000;
+    let receiver_amount = amount - tw_fee - platform_commission;
+
+    assert_eq!(usdc_token.0.balance(&trustless_work), tw_fee);
+    assert_eq!(usdc_token.0.balance(&platform), platform_commission);
+    assert_eq!(usdc_token.0.balance(&receiver), receiver_amount);
+    assert_eq!(usdc_token.0.balance(&client.address), 0);
+}
+
+

--- a/contracts/escrow/src/tests/dispute.rs
+++ b/contracts/escrow/src/tests/dispute.rs
@@ -31,6 +31,8 @@ fn test_dispute_management() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -118,6 +120,8 @@ fn test_dispute_resolution_process() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -285,6 +289,8 @@ fn test_dispute_escrow_authorized_and_unauthorized() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -371,6 +377,8 @@ fn test_resolve_dispute_rounding_edge_case() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, ""),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -26,12 +26,16 @@ fn test_initialize_excrow() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -128,12 +132,16 @@ fn test_update_escrow() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -185,18 +193,24 @@ fn test_update_escrow() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone updated"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Third milestone new"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -271,6 +285,8 @@ fn test_update_escrow_platform_fee_too_high() {
             status: String::from_str(&env, "pending"),
             evidence: String::from_str(&env, "e"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -354,6 +370,8 @@ fn test_initialize_escrow_platform_fee_too_high() {
             status: String::from_str(&env, "pending"),
             evidence: String::from_str(&env, "e"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 

--- a/contracts/escrow/src/tests/fund.rs
+++ b/contracts/escrow/src/tests/fund.rs
@@ -32,6 +32,8 @@ fn test_fund_escrow_successful_deposit() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -130,6 +132,8 @@ fn test_fund_escrow_signer_insufficient_funds_error() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -211,12 +215,16 @@ fn test_release_funds_successful_flow() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone"),
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -331,12 +339,16 @@ fn test_release_funds_milestones_incomplete() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
-            approved: false, // Not approved yet
+            approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -416,6 +428,8 @@ fn test_release_funds_same_receiver_as_provider() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -525,6 +539,8 @@ fn test_release_funds_invalid_receiver_fallback() {
             status: String::from_str(&env, "Completed"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -648,6 +664,8 @@ fn test_withdraw_remaining_funds_rounding_edge_case() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, ""),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 

--- a/contracts/escrow/src/tests/milestone.rs
+++ b/contracts/escrow/src/tests/milestone.rs
@@ -30,12 +30,16 @@ fn test_append_milestones_with_funds() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -91,6 +95,8 @@ fn test_append_milestones_with_funds() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -164,12 +170,16 @@ fn test_append_milestones_with_funds_and_existing_approved() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Second milestone"),
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -229,6 +239,8 @@ fn test_append_milestones_with_funds_and_existing_approved() {
             status: String::from_str(&env, "Pending"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 
@@ -307,12 +319,16 @@ fn test_change_milestone_status_and_approved() {
             status: String::from_str(&env, "in-progress"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
         Milestone {
             description: String::from_str(&env, "Milestone 2"),
             status: String::from_str(&env, "in-progress"),
             evidence: String::from_str(&env, "Initial evidence"),
             approved: false,
+            cross_chain_destination_domain: None,
+            cross_chain_recipient: None,
         },
     ];
 

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod helpers;
 
 mod balance;
+mod cross_chain;
 mod dispute;
 mod escrow;
 mod fund;


### PR DESCRIPTION
## Summary

Extends the milestone release mechanism to send USDC cross-chain (via CCTP) instead of only to a Stellar address. When a milestone has \cross_chain_destination_domain\ and \cross_chain_recipient\ set, the release function burns USDC via Circle's TokenMessengerMinter on Stellar, allowing the recipient to mint native USDC on the destination chain.

## Changes

### Storage types (\storage/types.rs\)
- Added \cross_chain_destination_domain: Option<u32>\ and \cross_chain_recipient: Option<Bytes>\ fields to the \Milestone\ struct
- Both default to \None\ for full backwards compatibility

### CCTP module (\cctp/\)
- \constants.rs\: Named constants for all supported CCTP domains (Ethereum 0, Avalanche 1, OP Mainnet 2, Arbitrum 3, Solana 5, Base 6, Polygon PoS 7)
- \constants.rs\: Testnet contract addresses for TokenMessengerMinter and MessageTransmitter (from Circle's official docs)
- \constants.rs\: \	runcate_to_6_decimals()\ helper for Stellar USDC (7 decimals) to CCTP (6 decimals) conversion
- \	oken_messenger_client.rs\: \TokenMessengerClient\ for calling \deposit_for_burn\ on Circle's TokenMessengerMinter contract

### Release logic (\core/escrow.rs\)
- In \
elease_funds\, checks the first milestone for cross-chain fields
- If cross-chain: calls \deposit_for_burn\ via \TokenMessengerClient\, then sends any 7th-decimal remainder to the Stellar receiver
- If Stellar-only: existing SAC transfer path unchanged
- Fee deductions (TW fee + platform fee) are applied before the cross-chain burn, identical to the existing path

### Validation (\core/validators/escrow.rs\)
- \alidate_cross_chain_receivers()\: validates all milestones for valid CCTP domains (0-7) and non-zero recipients
- Called during both \initialize_escrow\ and \update_escrow\

### Error types (\error.rs\)
- Added \InvalidCctpDomain\ (47) and \InvalidCctpRecipient\ (48)

## Testing

All 23 tests pass (19 existing + 4 new):

\\\
running 23 tests
test tests::cross_chain::test_cross_chain_zero_recipient_validation ... ok
test tests::cross_chain::test_cross_chain_invalid_domain_validation ... ok
test tests::cross_chain::test_cross_chain_missing_recipient_validation ... ok
test tests::cross_chain::test_cross_chain_backwards_compatible ... ok
test result: ok. 23 passed; 0 failed
\\\

### New tests
1. **\	est_cross_chain_invalid_domain_validation\** — rejects domain 999
2. **\	est_cross_chain_zero_recipient_validation\** — rejects zero-byte recipient
3. **\	est_cross_chain_missing_recipient_validation\** — rejects domain without recipient
4. **\	est_cross_chain_backwards_compatible\** — confirms existing behavior unchanged when cross-chain fields are \None\

## Verification evidence

### 1. Backwards compatibility
Confirmed: when \cross_chain_destination_domain\ and \cross_chain_recipient\ are \None\, the release flow is identical to the original — fees are deducted correctly and the full \
eceiver_amount\ goes to \escrow.roles.receiver\.

### 2. Validation errors
- **Invalid domain (999)**: Returns \InvalidCctpDomain\ error at initialization
- **Zero-byte recipient**: Returns \InvalidCctpRecipient\ error at initialization
- **Missing recipient with domain**: Returns \InvalidCctpRecipient\ error at initialization

### 3. Decimal precision handling
The \	runcate_to_6_decimals\ function converts Stellar USDC (7 decimals) to CCTP amount (6 decimals):
- \
et_amount / 10\ = 6-decimal amount for burn
- \
et_amount % 10\ = 7th-decimal remainder sent to Stellar receiver

### 4. CCTP testnet addresses (from Circle docs)
- TokenMessengerMinter: \CDNG7HXAPBWICI2E3AUBP3YZWZELJLYSB6F5CC7WLDTLTHVM74SLRTHP\
- MessageTransmitter: \CBJ6MTCKKZG73PMDZCJMSFRD7DQEMI4FKDH7CGDSV4W6FHCRBCQAVVJY\

## Design decisions
- Chose inlined \cross_chain_destination_domain\ + \cross_chain_recipient\ fields on \Milestone\ (instead of a separate \CrossChainReceiver\ struct) to avoid serialization issues with Soroban's \contracttype\ derive macro for custom nested types
- The first milestone's cross-chain config determines the payout path (single escrow = single payout)

Closes #91