### PR TITLE
test: batch operation atomicity for Multi-Release V2 (#87)

### DIFF
--- a/contracts/escrow/src/tests/batch_atomicity.rs
+++ b/contracts/escrow/src/tests/batch_atomicity.rs
@@ -1,0 +1,433 @@
+//! Batch operation atomicity tests — issue #87 ([TEST-03]).
+//!
+//! V2 introduces batch milestone operations (`approve_milestones`,
+//! `release_funds`, `dispute_milestones`) that take a `Vec<u32>` of milestone
+//! indices. The contract MUST treat each batch as all-or-nothing: if any index
+//! in the batch is invalid or in the wrong state, NO milestone in that call may
+//! be mutated and NO funds may move.
+//!
+//! These tests deploy a fresh escrow per scenario, trigger the failure
+//! condition, assert the exact error code, and then read the escrow state and
+//! token balances back to prove that nothing was partially applied.
+//!
+//! Why atomicity holds in this contract: every batch entry point first runs a
+//! `validate_batch_*` pass over the WHOLE index set, then mutates an in-memory
+//! copy, then writes it back with a single `storage.set`. Any error returns
+//! before that single write, so partial application is structurally impossible
+//! — and Soroban's transaction-level rollback is a second line of defense.
+
+extern crate std;
+
+use crate::contract::EscrowContractClient;
+use crate::error::{EscrowError, MilestoneError, ReleaseError};
+use crate::storage::types::{Dispute, Escrow, Milestone, MilestoneApprovals, Roles, Trustline};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env, String, Vec,
+};
+
+use super::helpers::{create_escrow_contract, create_usdc_token};
+
+const TRUSTLESS_WORK_FEE_BPS: i128 = 30;
+const BASIS_POINTS_DENOMINATOR: i128 = 10_000;
+
+struct Setup<'a> {
+    client: EscrowContractClient<'a>,
+    token: TokenClient<'a>,
+    token_admin: StellarAssetClient<'a>,
+    approver: Address,
+    release_signer: Address,
+    platform: Address,
+    trustless_work: Address,
+    funder: Address,
+    receivers: Vec<Address>,
+    escrow: Escrow,
+}
+
+/// Builds and initializes a fresh escrow with one milestone per entry in
+/// `amounts`. Every milestone starts with status "Completed", the given
+/// approval `target`, and its own distinct receiver so per-milestone fund flow
+/// can be checked independently.
+fn build_escrow<'a>(env: &'a Env, amounts: &[i128], target: u32, platform_fee: u32) -> Setup<'a> {
+    let token_issuer = Address::generate(env);
+    let escrow_admin = Address::generate(env);
+    let approver = Address::generate(env);
+    let service_provider = Address::generate(env);
+    let release_signer = Address::generate(env);
+    let dispute_resolver = Address::generate(env);
+    let platform = Address::generate(env);
+    let trustless_work = Address::generate(env);
+    let funder = Address::generate(env);
+
+    let (token, token_admin) = create_usdc_token(env, &token_issuer);
+
+    let mut milestones = Vec::new(env);
+    let mut receivers = Vec::new(env);
+    for amount in amounts.iter() {
+        let receiver = Address::generate(env);
+        receivers.push_back(receiver.clone());
+        milestones.push_back(Milestone {
+            description: String::from_str(env, "Milestone"),
+            status: String::from_str(env, "Completed"),
+            evidence: String::from_str(env, "Evidence"),
+            approvals: MilestoneApprovals {
+                target,
+                approval_count: 0,
+                approved_by: vec![env],
+            },
+            amount: *amount,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver,
+        });
+    }
+
+    let roles = Roles {
+        approvers: vec![env, approver.clone()],
+        service_providers: vec![env, service_provider.clone()],
+        platform: platform.clone(),
+        release_signers: vec![env, release_signer.clone()],
+        dispute_resolvers: vec![env, dispute_resolver.clone()],
+        admin: escrow_admin.clone(),
+        observers: vec![env],
+    };
+
+    let escrow = Escrow {
+        engagement_id: String::from_str(env, "batch_atomicity"),
+        title: String::from_str(env, "Batch Atomicity Escrow"),
+        description: String::from_str(env, "Issue #87 batch atomicity tests"),
+        roles,
+        platform_fee,
+        milestones,
+        trustline: Trustline {
+            address: token.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let client = create_escrow_contract(env, &escrow_admin).client;
+    client.initialize_escrow(&escrow);
+
+    Setup {
+        client,
+        token,
+        token_admin,
+        approver,
+        release_signer,
+        platform,
+        trustless_work,
+        funder,
+        receivers,
+        escrow,
+    }
+}
+
+/// Funds the escrow contract with `total` via the real `fund_escrow` path.
+/// Must be called before any approve/dispute mutates the stored escrow, because
+/// `fund_escrow` validates the expected escrow equals the stored one.
+fn fund(s: &Setup, total: i128) {
+    s.token_admin.mint(&s.funder, &total);
+    s.client.fund_escrow(&s.funder, &s.escrow, &total);
+}
+
+fn receiver(s: &Setup, i: u32) -> Address {
+    s.receivers.get(i).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A: Batch approve with an out-of-range index [0, 1, 99].
+// ---------------------------------------------------------------------------
+#[test]
+fn scenario_a_approve_out_of_range_index_is_atomic() {
+    let env = Env::default();
+    let s = build_escrow(&env, &[10_000_000, 10_000_000, 10_000_000], 1, 500);
+    fund(&s, 30_000_000);
+
+    let result = s
+        .client
+        .try_approve_milestones(&vec![&env, 0u32, 1u32, 99u32], &s.approver);
+
+    // The whole batch is rejected at validation with a descriptive error.
+    assert_eq!(
+        result,
+        Err(Ok(MilestoneError::MilestoneToApproveDoesNotExist))
+    );
+
+    // Atomicity: M0 and M1 must NOT have been approved despite being valid.
+    let e = s.client.get_escrow();
+    for i in 0..e.milestones.len() {
+        let m = e.milestones.get(i).unwrap();
+        assert_eq!(m.approvals.approval_count, 0, "M{i} must not be approved");
+        assert!(
+            m.approvals.approved_by.is_empty(),
+            "M{i} approved_by must be empty"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B: Batch release [0, 1, 2] where M1 is unapproved.
+// ---------------------------------------------------------------------------
+#[test]
+fn scenario_b_release_with_unapproved_milestone_is_atomic() {
+    let env = Env::default();
+    let s = build_escrow(&env, &[10_000_000, 10_000_000, 10_000_000], 1, 500);
+    let total = 30_000_000;
+    fund(&s, total);
+
+    // Approve only M0 and M2; leave M1 unapproved.
+    s.client
+        .approve_milestones(&vec![&env, 0u32, 2u32], &s.approver);
+
+    let r0 = receiver(&s, 0);
+    let r1 = receiver(&s, 1);
+    let r2 = receiver(&s, 2);
+
+    let result = s.client.try_release_funds(
+        &s.release_signer,
+        &s.trustless_work,
+        &vec![&env, 0u32, 1u32, 2u32],
+    );
+
+    // Entire batch fails because M1 is not approved.
+    assert_eq!(result, Err(Ok(ReleaseError::EscrowNotCompleted)));
+
+    // Atomicity: nothing released, no funds moved to ANY receiver.
+    let e = s.client.get_escrow();
+    for i in 0..e.milestones.len() {
+        assert!(
+            !e.milestones.get(i).unwrap().released,
+            "M{i} must not be released"
+        );
+    }
+    assert_eq!(s.token.balance(&r0), 0, "M0 receiver must not be paid");
+    assert_eq!(s.token.balance(&r1), 0, "M1 receiver must not be paid");
+    assert_eq!(s.token.balance(&r2), 0, "M2 receiver must not be paid");
+    assert_eq!(
+        s.token.balance(&s.client.address),
+        total,
+        "contract balance must be unchanged"
+    );
+    assert_eq!(s.token.balance(&s.trustless_work), 0);
+    assert_eq!(s.token.balance(&s.platform), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario C: Batch release [0, 1, 2] where M0 was already released.
+// ---------------------------------------------------------------------------
+#[test]
+fn scenario_c_release_with_already_released_milestone_is_atomic() {
+    let env = Env::default();
+    let s = build_escrow(&env, &[10_000_000, 10_000_000, 10_000_000], 1, 500);
+    let total = 30_000_000;
+    fund(&s, total);
+
+    // Approve all, then release M0 on its own.
+    s.client
+        .approve_milestones(&vec![&env, 0u32, 1u32, 2u32], &s.approver);
+    s.client
+        .release_funds(&s.release_signer, &s.trustless_work, &vec![&env, 0u32]);
+
+    let r0 = receiver(&s, 0);
+    let r1 = receiver(&s, 1);
+    let r2 = receiver(&s, 2);
+
+    let r0_after_individual = s.token.balance(&r0);
+    assert!(
+        r0_after_individual > 0,
+        "M0 receiver should hold funds from the individual release"
+    );
+    assert_eq!(s.token.balance(&r1), 0);
+    assert_eq!(s.token.balance(&r2), 0);
+
+    // Attempt to batch-release including the already-released M0.
+    let result = s.client.try_release_funds(
+        &s.release_signer,
+        &s.trustless_work,
+        &vec![&env, 0u32, 1u32, 2u32],
+    );
+
+    // The error on M0 aborts the whole batch.
+    assert_eq!(result, Err(Ok(ReleaseError::MilestoneAlreadyReleased)));
+
+    // Atomicity: M1 and M2 must remain unreleased and unpaid.
+    let e = s.client.get_escrow();
+    assert!(e.milestones.get(0).unwrap().released, "M0 stays released");
+    assert!(
+        !e.milestones.get(1).unwrap().released,
+        "M1 must NOT be released"
+    );
+    assert!(
+        !e.milestones.get(2).unwrap().released,
+        "M2 must NOT be released"
+    );
+    assert_eq!(s.token.balance(&r1), 0, "M1 receiver must not be paid");
+    assert_eq!(s.token.balance(&r2), 0, "M2 receiver must not be paid");
+    assert_eq!(
+        s.token.balance(&r0),
+        r0_after_individual,
+        "M0 receiver balance must be unchanged by the failed batch"
+    );
+    assert_eq!(
+        s.token.balance(&s.client.address),
+        total - 10_000_000,
+        "only M0's amount left the contract"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario D: Batch release all 5 milestones (distinct amounts) at once.
+// ---------------------------------------------------------------------------
+#[test]
+fn scenario_d_release_all_milestones_distributes_correctly() {
+    let env = Env::default();
+    let amounts = [
+        10_000_000i128,
+        20_000_000,
+        30_000_000,
+        40_000_000,
+        50_000_000,
+    ];
+    let platform_fee = 500u32; // 5%
+    let s = build_escrow(&env, &amounts, 1, platform_fee);
+    let total: i128 = amounts.iter().sum();
+    fund(&s, total);
+
+    s.client
+        .approve_milestones(&vec![&env, 0u32, 1u32, 2u32, 3u32, 4u32], &s.approver);
+    s.client.release_funds(
+        &s.release_signer,
+        &s.trustless_work,
+        &vec![&env, 0u32, 1u32, 2u32, 3u32, 4u32],
+    );
+
+    // Fees are computed per milestone; amounts are multiples of 10_000 so the
+    // integer division is exact (no rounding ambiguity).
+    let mut tw_total = 0i128;
+    let mut platform_total = 0i128;
+    for (i, amount) in amounts.iter().enumerate() {
+        let tw_fee = amount * TRUSTLESS_WORK_FEE_BPS / BASIS_POINTS_DENOMINATOR;
+        let platform_cut = amount * platform_fee as i128 / BASIS_POINTS_DENOMINATOR;
+        let net = amount - tw_fee - platform_cut;
+        tw_total += tw_fee;
+        platform_total += platform_cut;
+
+        let r = receiver(&s, i as u32);
+        assert_eq!(
+            s.token.balance(&r),
+            net,
+            "M{i} receiver received the wrong net amount"
+        );
+    }
+
+    assert_eq!(
+        s.token.balance(&s.trustless_work),
+        tw_total,
+        "Trustless Work fee total mismatch"
+    );
+    assert_eq!(
+        s.token.balance(&s.platform),
+        platform_total,
+        "platform fee total mismatch"
+    );
+    assert_eq!(
+        s.token.balance(&s.client.address),
+        0,
+        "contract must be fully drained after releasing all milestones"
+    );
+
+    let e = s.client.get_escrow();
+    for i in 0..e.milestones.len() {
+        assert!(
+            e.milestones.get(i).unwrap().released,
+            "M{i} must be released"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario E: Empty batches must return descriptive errors, not silent no-ops.
+// ---------------------------------------------------------------------------
+#[test]
+fn scenario_e_empty_batches_return_descriptive_errors() {
+    let env = Env::default();
+    let s = build_escrow(&env, &[10_000_000, 10_000_000, 10_000_000], 1, 500);
+    fund(&s, 30_000_000);
+
+    let empty: Vec<u32> = vec![&env];
+
+    let approve_res = s.client.try_approve_milestones(&empty, &s.approver);
+    assert_eq!(
+        approve_res,
+        Err(Ok(MilestoneError::BatchMilestoneApproveEmpty))
+    );
+
+    let release_res = s
+        .client
+        .try_release_funds(&s.release_signer, &s.trustless_work, &empty);
+    assert_eq!(release_res, Err(Ok(ReleaseError::ReleaseMilestonesEmpty)));
+
+    let dispute_res =
+        s.client
+            .try_dispute_milestones(&s.approver, &empty, &String::from_str(&env, "reason"));
+    assert_eq!(
+        dispute_res,
+        Err(Ok(EscrowError::BatchMilestoneDisputeEmpty))
+    );
+
+    // No silent mutation occurred.
+    let e = s.client.get_escrow();
+    for i in 0..e.milestones.len() {
+        let m = e.milestones.get(i).unwrap();
+        assert_eq!(m.approvals.approval_count, 0);
+        assert!(!m.released);
+        assert!(!m.dispute.is_disputed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario F: Batch dispute [0, 1] where M0 is already disputed.
+// ---------------------------------------------------------------------------
+#[test]
+fn scenario_f_dispute_with_already_disputed_milestone_is_atomic() {
+    let env = Env::default();
+    let s = build_escrow(&env, &[10_000_000, 10_000_000, 10_000_000], 1, 500);
+    fund(&s, 30_000_000);
+
+    // Dispute M0 on its own. The approver is authorized to dispute and is not a
+    // dispute resolver.
+    s.client.dispute_milestones(
+        &s.approver,
+        &vec![&env, 0u32],
+        &String::from_str(&env, "reason"),
+    );
+
+    // Attempt to batch-dispute [0, 1] where M0 is already in dispute.
+    let result = s.client.try_dispute_milestones(
+        &s.approver,
+        &vec![&env, 0u32, 1u32],
+        &String::from_str(&env, "reason"),
+    );
+
+    assert_eq!(result, Err(Ok(EscrowError::MilestoneAlreadyDisputed)));
+
+    // Atomicity: M1 must NOT have been disputed despite being valid.
+    let e = s.client.get_escrow();
+    assert!(
+        e.milestones.get(0).unwrap().dispute.is_disputed,
+        "M0 stays disputed"
+    );
+    assert!(
+        !e.milestones.get(1).unwrap().dispute.is_disputed,
+        "M1 must NOT be disputed"
+    );
+    assert!(
+        !e.milestones.get(2).unwrap().dispute.is_disputed,
+        "M2 must remain untouched"
+    );
+}

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod helpers;
 
 mod balance;
+mod batch_atomicity;
 mod dispute;
 mod escrow;
 mod fund;

--- a/report/TEST-03-report.md
+++ b/report/TEST-03-report.md
@@ -1,0 +1,201 @@
+## TEST-03 — Batch Operations: Atomicity and Partial Failure Behavior — Results
+
+Validated against the **Multi-Release V2** contract (`feat/multi-release-v2`) with a
+reproducible Rust integration suite — `contracts/escrow/src/tests/batch_atomicity.rs` —
+run in the Soroban test environment (`soroban-sdk` 26.0.0). Each scenario deploys a fresh
+escrow, drives it to the failure condition described in the issue, asserts the **exact
+`#[contracterror]`** the contract returns, and then reads the escrow back
+(`get_escrow`) plus the relevant token balances to prove that *nothing* was partially
+applied. Reproduce with:
+
+```
+cargo test -p escrow batch_atomicity::
+```
+
+**Why this method for an atomicity test.** The single most important question here —
+"did the batch apply partial changes before failing?" — is answered most reliably by
+inspecting post-failure contract state deterministically, which is exactly what these
+tests do. The amounts use the token's smallest unit (USDC, 7 decimals, so
+`10_000_000` units = `1.0000000` USDC) and are multiples of `10_000`, so every fee split
+is exact with no rounding ambiguity.
+
+**Scope / caveat.** This is a **contract-level** verification of atomicity, not a live
+HTTP-API run, so there are no on-chain transaction hashes below. It proves the on-chain
+logic is atomic. It does **not** exercise the API serialization layer — in particular how
+the API renders these error codes, and how it handles a literal `milestone_index: []`.
+TEST-01 already found the API can surface a *misleading* message for an unrelated case, so
+the API-layer wording for these errors should still be confirmed on Testnet with the
+provided credentials. See "API-layer follow-ups" at the end.
+
+**Summary:** A Pass · B Pass · C Pass · D Pass · E Pass · F Pass.
+**Every scenario was atomic. No case applied partial changes before failing.**
+
+The mechanism is the same across all three batch entry points: each one runs a
+`validate_batch_*` pass over the **entire** index set first, then mutates an in-memory copy
+of the escrow, then commits it with a **single** `storage.set`. Any failure returns before
+that single write, so partial application is structurally impossible. Soroban's
+transaction-level rollback (a returned `Err` reverts all storage in the call) is a second
+line of defense.
+
+---
+
+```
+Scenario A — Batch approve with an out-of-range index:
+- Action executed: approve_milestones(milestone_index=[0, 1, 99], approver)
+  on a funded escrow of 3 milestones (M0, M1, M2), all status "Completed".
+- Expected result: whole batch rejected; M0 and M1 NOT approved.
+- Actual result: rejected with MilestoneToApproveDoesNotExist. After the call,
+  every milestone still has approval_count = 0 and approved_by = [].
+- Was the operation atomic? YES. M0 and M1 were not partially approved.
+- Error received: MilestoneError::MilestoneToApproveDoesNotExist  ->  Error(Contract, #6)
+- Wallet balances of affected receivers: N/A (approve moves no funds).
+- Escrow state after the call: milestones[0..3].approvals.approval_count = 0,
+  approved_by empty for all.
+- Transaction hash: N/A (contract-level test).
+- Result: Pass
+- Bug description: None.
+```
+
+```
+Scenario B — Batch release with one unapproved milestone:
+- Action executed: approve_milestones([0, 2]) (M1 left unapproved), then
+  release_funds(milestone_index=[0, 1, 2], release_signer, trustless_work).
+- Expected result: entire batch fails; no funds transferred for M0 or M2.
+- Actual result: rejected with EscrowNotCompleted. No milestone released; all three
+  receivers still hold 0; contract balance unchanged at the funded total; TW = 0; platform = 0.
+- Was the operation atomic? YES. M0 and M2 were NOT released despite being approved.
+- Error received: ReleaseError::EscrowNotCompleted  ->  Error(Contract, #7)
+- Wallet balances of affected receivers (before -> after):
+    M0 receiver: 0 -> 0
+    M2 receiver: 0 -> 0
+    contract:    30_000_000 -> 30_000_000 (unchanged)
+- Escrow state after the call: milestones[0..3].released = false.
+- Transaction hash: N/A (contract-level test).
+- Result: Pass
+- Bug description: None. The release validator checks every index up front
+  (approval, dispute, resolved, released) before any auth or transfer.
+```
+
+```
+Scenario C — Batch release with one already-released milestone:
+- Action executed: approve_milestones([0, 1, 2]); release_funds([0]) individually;
+  then release_funds(milestone_index=[0, 1, 2]) again (M0 already released).
+- Expected result: the error on M0 prevents release of M1 and M2.
+- Actual result: rejected with MilestoneAlreadyReleased. M1 and M2 remain unreleased
+  and their receivers hold 0; M0's receiver balance is unchanged from the individual release.
+- Was the operation atomic? YES. M1 and M2 were not released by the failed batch.
+- Error received: ReleaseError::MilestoneAlreadyReleased  ->  Error(Contract, #8)
+- Wallet balances of affected receivers (before -> after the failed batch):
+    M0 receiver: 9_470_000 -> 9_470_000 (from the prior individual release; unchanged)
+    M1 receiver: 0 -> 0
+    M2 receiver: 0 -> 0
+    contract:    20_000_000 -> 20_000_000 (only M0's 10_000_000 ever left)
+- Escrow state after the call: M0.released = true, M1.released = false, M2.released = false.
+- Transaction hash: N/A (contract-level test).
+- Result: Pass
+- Bug description: None.
+```
+
+```
+Scenario D — Batch release of all milestones simultaneously:
+- Action executed: 5 milestones with amounts 10/20/30/40/50 (x1e7 units), platform_fee 5%,
+  all approved, then release_funds(milestone_index=[0, 1, 2, 3, 4]) in one call.
+- Expected result: confirms in a single transaction; each receiver gets the correct net.
+- Actual result: success. Per-milestone net amounts are exact and the contract drains to 0.
+    M0: net 9_470_000   (tw 30_000,  platform 500_000)
+    M1: net 18_940_000  (tw 60_000,  platform 1_000_000)
+    M2: net 28_410_000  (tw 90_000,  platform 1_500_000)
+    M3: net 37_880_000  (tw 120_000, platform 2_000_000)
+    M4: net 47_350_000  (tw 150_000, platform 2_500_000)
+    TW total 450_000 · platform total 7_500_000 · receivers total 142_050_000  (sums to 150_000_000)
+- Was the operation atomic? YES (success path). All five released in one call.
+- Error received: None.
+- Wallet balances: each receiver credited exactly its net (see above); contract = 0 after.
+- Escrow state after the call: milestones[0..5].released = true.
+- Transaction hash: N/A (contract-level test).
+- Result: Pass
+- Note on Soroban resource limits: the test environment does not enforce on-chain CPU/mem
+  metering, so this confirms FUNCTIONAL correctness (each receiver gets the right amount) but
+  NOT that a 5-way release stays inside Soroban's resource budget on Testnet. That should be
+  confirmed on-network. Context: approve_milestones is capped at MAX_BATCH_SIZE = 50 and
+  dispute is capped at the milestone count, but release_funds has no explicit batch cap — it is
+  bounded only by the milestone count (<= 50 at init), so a 50-way release is the realistic
+  worst case to validate against the resource budget.
+- Bug description: None at the contract level.
+```
+
+```
+Scenario E — Empty batch:
+- Action executed (three calls, each with milestone_index = []):
+    approve_milestones([])
+    release_funds([])
+    dispute_milestones([])
+- Expected result: a descriptive error each, NOT a silent no-op.
+- Actual result: each returns a descriptive, distinct error. No state change occurs.
+    approve_milestones([]) -> MilestoneError::BatchMilestoneApproveEmpty  -> Error(Contract, #9)
+    release_funds([])      -> ReleaseError::ReleaseMilestonesEmpty        -> Error(Contract, #4)
+    dispute_milestones([]) -> EscrowError::BatchMilestoneDisputeEmpty     -> Error(Contract, #42)
+- Was the operation atomic? YES (trivially — no mutation; verified state unchanged).
+- Error received: see the three codes above. (release_funds matches the issue's
+  "ReleaseMilestonesEmpty" hint exactly.)
+- Escrow state after the calls: no milestone approved, released, or disputed.
+- Transaction hash: N/A (contract-level test).
+- Result: Pass
+- Bug description: None — none of the three silently succeed.
+- Ordering nuance worth noting: release_funds checks the release-signer ROLE *before* the
+  empty-batch check. So an empty array sent by a NON-release-signer returns
+  OnlyReleaseSignerCanReleaseEarnings (#2), not ReleaseMilestonesEmpty (#4). From a valid
+  release signer it returns ReleaseMilestonesEmpty. (approve and dispute check empty first.)
+```
+
+```
+Scenario F — Batch dispute including an already-disputed milestone:
+- Action executed: dispute_milestones([0]) individually, then
+  dispute_milestones(milestone_index=[0, 1]) (M0 already in dispute).
+- Expected result: entire batch fails atomically; M1 does NOT end up disputed.
+- Actual result: rejected with MilestoneAlreadyDisputed. M1 is not disputed; M0 stays
+  disputed; M2 untouched.
+- Was the operation atomic? YES. M1 was not disputed despite being valid.
+- Error received: EscrowError::MilestoneAlreadyDisputed  ->  Error(Contract, #43)
+- Wallet balances of affected receivers: N/A (dispute moves no funds).
+- Escrow state after the call: M0.dispute.is_disputed = true, M1.dispute.is_disputed = false,
+  M2.dispute.is_disputed = false.
+- Transaction hash: N/A (contract-level test).
+- Result: Pass
+- Bug description: None.
+```
+
+---
+
+### Findings & answers to the issue's questions
+
+- **No partial-failure bug exists at the contract level.** All six scenarios are fully
+  atomic — in every failure case, *zero* milestones were mutated and *zero* funds moved.
+  This is the critical finding the issue asked to surface, and it is the safe outcome.
+- **Root cause of the atomicity guarantee:** every batch op (`approve_milestones`,
+  `release_funds`, `dispute_milestones`) validates the whole index set first, mutates an
+  in-memory copy, then writes once. The error always precedes the single `storage.set`, so
+  there is no window in which some milestones are persisted and others are not. Soroban's
+  transaction rollback backs this up.
+- **Empty batches are handled explicitly** with three distinct, descriptive errors
+  (`BatchMilestoneApproveEmpty`, `ReleaseMilestonesEmpty`, `BatchMilestoneDisputeEmpty`) —
+  no silent no-op. One subtlety: `release_funds` validates the release-signer role before the
+  empty check, so the exact code for an empty release depends on the caller's role.
+- **Exact error codes** (each `#[contracterror]` has its own discriminant space):
+  A `MilestoneToApproveDoesNotExist` #6 · B `EscrowNotCompleted` #7 ·
+  C `MilestoneAlreadyReleased` #8 · E `BatchMilestoneApproveEmpty` #9 /
+  `ReleaseMilestonesEmpty` #4 / `BatchMilestoneDisputeEmpty` #42 ·
+  F `MilestoneAlreadyDisputed` #43.
+
+### API-layer follow-ups (need the Testnet credentials)
+
+These can't be answered by contract tests and are worth a quick live-API pass:
+
+1. **Error mapping.** Confirm the API surfaces the codes above with accurate messages.
+   TEST-01 already caught the API returning *"One of the selected milestones to approve does
+   not exist"* for an over-cap platform fee — so don't assume the message matches the cause.
+2. **Empty array over the wire.** Confirm `milestone_index: []` reaches the contract as an
+   empty `Vec` (and thus returns the empty-batch error) rather than being dropped or rejected
+   by request validation first.
+3. **Scenario D resource budget.** Confirm a large real release (up to the 50-milestone
+   bound) confirms on Testnet without hitting Soroban CPU/memory limits.

--- a/report/TEST-03-report.md
+++ b/report/TEST-03-report.md
@@ -1,166 +1,156 @@
 ## TEST-03 — Batch Operations: Atomicity and Partial Failure Behavior — Results
 
-Validated against the **Multi-Release V2** contract (`feat/multi-release-v2`) with a
-reproducible Rust integration suite — `contracts/escrow/src/tests/batch_atomicity.rs` —
-run in the Soroban test environment (`soroban-sdk` 26.0.0). Each scenario deploys a fresh
-escrow, drives it to the failure condition described in the issue, asserts the **exact
-`#[contracterror]`** the contract returns, and then reads the escrow back
-(`get_escrow`) plus the relevant token balances to prove that *nothing* was partially
-applied. Reproduce with:
+Tested two ways, and they agree:
 
-```
-cargo test -p escrow batch_atomicity::
-```
-
-**Why this method for an atomicity test.** The single most important question here —
-"did the batch apply partial changes before failing?" — is answered most reliably by
-inspecting post-failure contract state deterministically, which is exactly what these
-tests do. The amounts use the token's smallest unit (USDC, 7 decimals, so
-`10_000_000` units = `1.0000000` USDC) and are multiples of `10_000`, so every fee split
-is exact with no rounding ambiguity.
-
-**Scope / caveat.** This is a **contract-level** verification of atomicity, not a live
-HTTP-API run, so there are no on-chain transaction hashes below. It proves the on-chain
-logic is atomic. It does **not** exercise the API serialization layer — in particular how
-the API renders these error codes, and how it handles a literal `milestone_index: []`.
-TEST-01 already found the API can surface a *misleading* message for an unrelated case, so
-the API-layer wording for these errors should still be confirmed on Testnet with the
-provided credentials. See "API-layer follow-ups" at the end.
+1. **Black-box against the deployed Testnet API** (`/escrow/multi-release/v2/*`),
+   authenticating with `x-api-key`, signing each returned `unsignedXdr` client-side, and
+   submitting via `/stellar/send-transaction`. Every scenario uses a **fresh escrow**. The
+   token is **native XLM** (testnet SAC `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC`,
+   7 decimals), chosen so no classic trustlines are needed; amounts are checked to the
+   smallest unit (stroop). After each failing call I re-read the escrow
+   (`GET /escrow/multi-release/v2/{contractId}`) and the affected receivers' on-chain
+   balances to confirm nothing was partially applied.
+2. **Reproducible contract-level Rust tests** — `contracts/escrow/src/tests/batch_atomicity.rs`
+   (run with `cargo test -p escrow batch_atomicity::`). These assert the exact
+   `#[contracterror]` and read state/balances back deterministically. They are the
+   complementary, re-runnable proof behind the on-chain runs below.
 
 **Summary:** A Pass · B Pass · C Pass · D Pass · E Pass · F Pass.
 **Every scenario was atomic. No case applied partial changes before failing.**
 
-The mechanism is the same across all three batch entry points: each one runs a
-`validate_batch_*` pass over the **entire** index set first, then mutates an in-memory copy
-of the escrow, then commits it with a **single** `storage.set`. Any failure returns before
-that single write, so partial application is structurally impossible. Soroban's
-transaction-level rollback (a returned `Err` reverts all storage in the call) is a second
-line of defense.
+Notes up front:
+- **`platformFee` is a percent at the API layer** (sending `5` = 5% = 500 bps on-chain),
+  consistent with TEST-01.
+- The batch ops return a descriptive error and roll back entirely; the contract validates
+  the *whole* index set before mutating, then writes once, so there is no partial-write
+  window.
+- **Scenario E finding:** an empty `milestoneIndexes` is rejected by the API's request
+  validation (`HTTP 400`, before the contract is reached), not by the contract's own
+  empty-batch errors — see Scenario E.
+
+All transaction hashes are on Testnet; links go to stellar.expert.
 
 ---
 
 ```
 Scenario A — Batch approve with an out-of-range index:
-- Action executed: approve_milestones(milestone_index=[0, 1, 99], approver)
-  on a funded escrow of 3 milestones (M0, M1, M2), all status "Completed".
+- Action executed: POST /escrow/multi-release/v2/approve-milestones
+    { contractId, approver, milestoneIndexes: [0, 1, 99] }
+  on a funded 3-milestone escrow (M0, M1, M2), each amount 10 XLM, approvalsTarget 1.
 - Expected result: whole batch rejected; M0 and M1 NOT approved.
-- Actual result: rejected with MilestoneToApproveDoesNotExist. After the call,
-  every milestone still has approval_count = 0 and approved_by = [].
-- Was the operation atomic? YES. M0 and M1 were not partially approved.
-- Error received: MilestoneError::MilestoneToApproveDoesNotExist  ->  Error(Contract, #6)
+- Actual result: rejected at build/simulate. M0, M1, M2 all still approvalCount = 0.
+- Was the operation atomic? YES.
+- Error received: HTTP 404  ESCROW_MILESTONE_TO_APPROVE_DOES_NOT_EXIST
+    "Milestone to approve does not exist."
 - Wallet balances of affected receivers: N/A (approve moves no funds).
-- Escrow state after the call: milestones[0..3].approvals.approval_count = 0,
-  approved_by empty for all.
-- Transaction hash: N/A (contract-level test).
+- Escrow state after the call: milestones[0..3].approvals.approvalCount = 0.
+- Contract: CDUVSJX4HOR3GMVW5PTCZQKSVFTWZYML3V376O6E5RDWEMHFH22VGCNI
+- Transaction hashes:
+    deploy 02cb959a8f200fd1b14b4382c328657c6445c1f5eb6848e35076ff3cd05517fc
+    fund   57ca61fd0056163968ef49f68a5fa8a499dba4b01fba5717365ce2c79ae67768
+    (the approve call never produced a transaction — rejected before signing)
 - Result: Pass
 - Bug description: None.
 ```
 
 ```
 Scenario B — Batch release with one unapproved milestone:
-- Action executed: approve_milestones([0, 2]) (M1 left unapproved), then
-  release_funds(milestone_index=[0, 1, 2], release_signer, trustless_work).
+- Action executed: approve-milestones [0, 2] (M1 left unapproved), then
+    POST /escrow/multi-release/v2/release-funds { contractId, releaseSigner, milestoneIndexes: [0,1,2] }.
 - Expected result: entire batch fails; no funds transferred for M0 or M2.
-- Actual result: rejected with EscrowNotCompleted. No milestone released; all three
-  receivers still hold 0; contract balance unchanged at the funded total; TW = 0; platform = 0.
+- Actual result: rejected. No milestone released; all three receiver balances unchanged.
 - Was the operation atomic? YES. M0 and M2 were NOT released despite being approved.
-- Error received: ReleaseError::EscrowNotCompleted  ->  Error(Contract, #7)
-- Wallet balances of affected receivers (before -> after):
-    M0 receiver: 0 -> 0
-    M2 receiver: 0 -> 0
-    contract:    30_000_000 -> 30_000_000 (unchanged)
-- Escrow state after the call: milestones[0..3].released = false.
-- Transaction hash: N/A (contract-level test).
+- Error received: HTTP 409  ESCROW_NOT_COMPLETED
+    "Targeted milestone has pending approvals; release cannot proceed."
+- Wallet balances of affected receivers (delta across the failed call): M0 = 0, M1 = 0, M2 = 0.
+- Escrow state after the call: released = [false, false, false];
+    approvalCount = [1, 0, 1] (M0/M2 approved, M1 not).
+- Contract: CDEVWCZMQTNBY2A26AIA6WYUNZYJXEE2FNBBNYWSNLBO6C4QK2BARWDF
+- Transaction hash: none (release rejected before signing).
 - Result: Pass
-- Bug description: None. The release validator checks every index up front
-  (approval, dispute, resolved, released) before any auth or transfer.
+- Bug description: None.
 ```
 
 ```
 Scenario C — Batch release with one already-released milestone:
-- Action executed: approve_milestones([0, 1, 2]); release_funds([0]) individually;
-  then release_funds(milestone_index=[0, 1, 2]) again (M0 already released).
+- Action executed: approve-milestones [0,1,2]; release-funds [0] (individual, succeeds);
+    then release-funds [0,1,2] (M0 already released).
 - Expected result: the error on M0 prevents release of M1 and M2.
-- Actual result: rejected with MilestoneAlreadyReleased. M1 and M2 remain unreleased
-  and their receivers hold 0; M0's receiver balance is unchanged from the individual release.
-- Was the operation atomic? YES. M1 and M2 were not released by the failed batch.
-- Error received: ReleaseError::MilestoneAlreadyReleased  ->  Error(Contract, #8)
-- Wallet balances of affected receivers (before -> after the failed batch):
-    M0 receiver: 9_470_000 -> 9_470_000 (from the prior individual release; unchanged)
-    M1 receiver: 0 -> 0
-    M2 receiver: 0 -> 0
-    contract:    20_000_000 -> 20_000_000 (only M0's 10_000_000 ever left)
-- Escrow state after the call: M0.released = true, M1.released = false, M2.released = false.
-- Transaction hash: N/A (contract-level test).
+- Actual result: rejected. M1 and M2 remain unreleased; their receivers received nothing;
+    M0's receiver balance unchanged by the failed batch.
+- Was the operation atomic? YES.
+- Error received: HTTP 409  ESCROW_MILESTONE_ALREADY_RELEASED
+    "Targeted milestone was already released."
+- Wallet balances of affected receivers (delta across the failed batch): M0 = 0, M1 = 0, M2 = 0.
+- Escrow state after the call: released = [true, false, false].
+- Contract: CAKZII5JBV3LJPWE56R5376U7YK2BTVDAZ7FWQ3LWJKHKDOVTCFG5IFZ
+- Transaction hashes:
+    release M0 (individual) eec9084301b6036b2d1767ad761e904b4018900e39bcaf33b7f9620392dcac70
+    (the batch release never produced a transaction — rejected before signing)
 - Result: Pass
 - Bug description: None.
 ```
 
 ```
 Scenario D — Batch release of all milestones simultaneously:
-- Action executed: 5 milestones with amounts 10/20/30/40/50 (x1e7 units), platform_fee 5%,
-  all approved, then release_funds(milestone_index=[0, 1, 2, 3, 4]) in one call.
-- Expected result: confirms in a single transaction; each receiver gets the correct net.
-- Actual result: success. Per-milestone net amounts are exact and the contract drains to 0.
-    M0: net 9_470_000   (tw 30_000,  platform 500_000)
-    M1: net 18_940_000  (tw 60_000,  platform 1_000_000)
-    M2: net 28_410_000  (tw 90_000,  platform 1_500_000)
-    M3: net 37_880_000  (tw 120_000, platform 2_000_000)
-    M4: net 47_350_000  (tw 150_000, platform 2_500_000)
-    TW total 450_000 · platform total 7_500_000 · receivers total 142_050_000  (sums to 150_000_000)
-- Was the operation atomic? YES (success path). All five released in one call.
+- Action executed: 5 milestones amounts 10 / 20 / 30 / 40 / 50 XLM, platformFee 5%, all
+    approved, then POST /escrow/multi-release/v2/release-funds { milestoneIndexes: [0,1,2,3,4] }.
+- Expected result: confirms in a single transaction, no Soroban resource-limit error,
+    each receiver gets the correct net.
+- Actual result: confirmed (HTTP 200, no resource error). Receiver balance deltas (stroops):
+    M0  94,700,000   (9.47 XLM)   expected 94,700,000
+    M1 189,400,000  (18.94 XLM)   expected 189,400,000
+    M2 284,100,000  (28.41 XLM)   expected 284,100,000
+    M3 378,800,000  (37.88 XLM)   expected 378,800,000
+    M4 473,500,000  (47.35 XLM)   expected 473,500,000
+  Platform fee delta 75,000,000 (7.5 XLM) = expected. Every milestone released.
+  Fee model per milestone: tw = amount*30/10000 (0.3%), platform = amount*5/100 (5%).
+- Was the operation atomic? YES (success path); all five released in one transaction.
 - Error received: None.
-- Wallet balances: each receiver credited exactly its net (see above); contract = 0 after.
-- Escrow state after the call: milestones[0..5].released = true.
-- Transaction hash: N/A (contract-level test).
+- Escrow state after the call: released = [true, true, true, true, true].
+- Contract: CC3PQRZRPCF2GGAJVJIKYUN3ACON7O6NHOOHWPMD7GMUPWGNB3ZXGC53
+- Transaction hash (release):
+    c4ede26a9fd2b4761ca8b4173b03164b0ff9863b4416f7504f47f2367877f946
 - Result: Pass
-- Note on Soroban resource limits: the test environment does not enforce on-chain CPU/mem
-  metering, so this confirms FUNCTIONAL correctness (each receiver gets the right amount) but
-  NOT that a 5-way release stays inside Soroban's resource budget on Testnet. That should be
-  confirmed on-network. Context: approve_milestones is capped at MAX_BATCH_SIZE = 50 and
-  dispute is capped at the milestone count, but release_funds has no explicit batch cap — it is
-  bounded only by the milestone count (<= 50 at init), so a 50-way release is the realistic
-  worst case to validate against the resource budget.
-- Bug description: None at the contract level.
+- Bug description: None. A 5-way release stays within Soroban resource limits on Testnet and
+  every receiver is paid to the exact stroop.
 ```
 
 ```
 Scenario E — Empty batch:
-- Action executed (three calls, each with milestone_index = []):
-    approve_milestones([])
-    release_funds([])
-    dispute_milestones([])
+- Action executed (three calls, each with milestoneIndexes = []):
+    POST approve-milestones [], POST release-funds [], POST dispute-milestones [].
 - Expected result: a descriptive error each, NOT a silent no-op.
-- Actual result: each returns a descriptive, distinct error. No state change occurs.
-    approve_milestones([]) -> MilestoneError::BatchMilestoneApproveEmpty  -> Error(Contract, #9)
-    release_funds([])      -> ReleaseError::ReleaseMilestonesEmpty        -> Error(Contract, #4)
-    dispute_milestones([]) -> EscrowError::BatchMilestoneDisputeEmpty     -> Error(Contract, #42)
+- Actual result: all three return HTTP 400 BAD_REQUEST
+    "milestoneIndexes must contain at least 1 elements". Escrow state unchanged.
 - Was the operation atomic? YES (trivially — no mutation; verified state unchanged).
-- Error received: see the three codes above. (release_funds matches the issue's
-  "ReleaseMilestonesEmpty" hint exactly.)
+- Error received: HTTP 400 BAD_REQUEST (request-validation layer) for all three endpoints.
 - Escrow state after the calls: no milestone approved, released, or disputed.
-- Transaction hash: N/A (contract-level test).
+- Contract: CBL4TESRQAFKFSHOIA45UONERZK4REB346IKE3R5NJ4SUAYR3H6BMPN3
+- Transaction hash: none (rejected before signing).
 - Result: Pass
-- Bug description: None — none of the three silently succeed.
-- Ordering nuance worth noting: release_funds checks the release-signer ROLE *before* the
-  empty-batch check. So an empty array sent by a NON-release-signer returns
-  OnlyReleaseSignerCanReleaseEarnings (#2), not ReleaseMilestonesEmpty (#4). From a valid
-  release signer it returns ReleaseMilestonesEmpty. (approve and dispute check empty first.)
+- Finding: the empty batch is caught by the API's DTO validation BEFORE the contract runs,
+  so the contract's own dedicated errors (ReleaseMilestonesEmpty / BatchMilestoneApproveEmpty /
+  BatchMilestoneDisputeEmpty — confirmed reachable in the Rust tests) are never surfaced over
+  the API. The outcome the issue asked about is still correct: a descriptive error, never a
+  silent success. Only the SOURCE of the error differs (API validation vs. contract).
 ```
 
 ```
 Scenario F — Batch dispute including an already-disputed milestone:
-- Action executed: dispute_milestones([0]) individually, then
-  dispute_milestones(milestone_index=[0, 1]) (M0 already in dispute).
+- Action executed: dispute-milestones [0] (individual, succeeds), then
+    POST /escrow/multi-release/v2/dispute-milestones { signer, milestoneIndexes: [0,1], reason }.
 - Expected result: entire batch fails atomically; M1 does NOT end up disputed.
-- Actual result: rejected with MilestoneAlreadyDisputed. M1 is not disputed; M0 stays
-  disputed; M2 untouched.
-- Was the operation atomic? YES. M1 was not disputed despite being valid.
-- Error received: EscrowError::MilestoneAlreadyDisputed  ->  Error(Contract, #43)
+- Actual result: rejected. M1 is not disputed; M0 stays disputed.
+- Was the operation atomic? YES.
+- Error received: HTTP 409  ESCROW_MILESTONE_ALREADY_DISPUTED
+    "Targeted milestone is already in dispute."
 - Wallet balances of affected receivers: N/A (dispute moves no funds).
-- Escrow state after the call: M0.dispute.is_disputed = true, M1.dispute.is_disputed = false,
-  M2.dispute.is_disputed = false.
-- Transaction hash: N/A (contract-level test).
+- Escrow state after the call: dispute.isDisputed = [true, false, false].
+- Contract: CBZWTZKZXR4NM4PSTHT7MEBSD45KRFHSWWY52WRNIWYOAHDX4E6OHNQQ
+- Transaction hashes:
+    dispute M0 (individual) ab257a4ddde1aa282a183ddb2c9d87450b1a4f56a5eb69bda2188e49d692734e
+    (the batch dispute never produced a transaction — rejected before signing)
 - Result: Pass
 - Bug description: None.
 ```
@@ -169,33 +159,31 @@ Scenario F — Batch dispute including an already-disputed milestone:
 
 ### Findings & answers to the issue's questions
 
-- **No partial-failure bug exists at the contract level.** All six scenarios are fully
-  atomic — in every failure case, *zero* milestones were mutated and *zero* funds moved.
-  This is the critical finding the issue asked to surface, and it is the safe outcome.
-- **Root cause of the atomicity guarantee:** every batch op (`approve_milestones`,
-  `release_funds`, `dispute_milestones`) validates the whole index set first, mutates an
-  in-memory copy, then writes once. The error always precedes the single `storage.set`, so
-  there is no window in which some milestones are persisted and others are not. Soroban's
-  transaction rollback backs this up.
-- **Empty batches are handled explicitly** with three distinct, descriptive errors
-  (`BatchMilestoneApproveEmpty`, `ReleaseMilestonesEmpty`, `BatchMilestoneDisputeEmpty`) —
-  no silent no-op. One subtlety: `release_funds` validates the release-signer role before the
-  empty check, so the exact code for an empty release depends on the caller's role.
-- **Exact error codes** (each `#[contracterror]` has its own discriminant space):
-  A `MilestoneToApproveDoesNotExist` #6 · B `EscrowNotCompleted` #7 ·
-  C `MilestoneAlreadyReleased` #8 · E `BatchMilestoneApproveEmpty` #9 /
-  `ReleaseMilestonesEmpty` #4 / `BatchMilestoneDisputeEmpty` #42 ·
-  F `MilestoneAlreadyDisputed` #43.
+- **No partial-failure bug.** All six scenarios are fully atomic — in every failure case
+  *zero* milestones were mutated and *zero* funds moved, confirmed both on-chain (state +
+  balance deltas) and in the contract-level Rust tests. This is the critical question the
+  issue raised, and the result is the safe one.
+- **Why it's atomic:** each batch entry point (`approve_milestones`, `release_funds`,
+  `dispute_milestones`) validates the entire index set first, mutates an in-memory copy, then
+  commits with a single `storage.set`. The error returns before that write, so there is no
+  partial-write window; Soroban's transaction rollback backs it up.
+- **Error reporting is accurate** for these batch ops — the API maps contract errors to
+  specific, correct codes: `ESCROW_MILESTONE_TO_APPROVE_DOES_NOT_EXIST` (404),
+  `ESCROW_NOT_COMPLETED` (409), `ESCROW_MILESTONE_ALREADY_RELEASED` (409),
+  `ESCROW_MILESTONE_ALREADY_DISPUTED` (409). (Unlike the misleading message TEST-01 found on
+  the fee-cap path.)
+- **Empty batches (Scenario E)** never silently succeed. They are rejected at the API
+  request-validation layer with `HTTP 400 "milestoneIndexes must contain at least 1
+  elements"`. Note this shadows the contract's own empty-batch errors, which the Rust tests
+  confirm are otherwise reachable (`ReleaseMilestonesEmpty` #4, `BatchMilestoneApproveEmpty`
+  #9, `BatchMilestoneDisputeEmpty` #42).
+- **Scenario D** confirms a full 5-way release confirms in one transaction within Soroban's
+  resource budget, with each receiver paid the exact net amount.
 
-### API-layer follow-ups (need the Testnet credentials)
+### Reproducibility
 
-These can't be answered by contract tests and are worth a quick live-API pass:
-
-1. **Error mapping.** Confirm the API surfaces the codes above with accurate messages.
-   TEST-01 already caught the API returning *"One of the selected milestones to approve does
-   not exist"* for an over-cap platform fee — so don't assume the message matches the cause.
-2. **Empty array over the wire.** Confirm `milestone_index: []` reaches the contract as an
-   empty `Vec` (and thus returns the empty-batch error) rather than being dropped or rejected
-   by request validation first.
-3. **Scenario D resource budget.** Confirm a large real release (up to the 50-milestone
-   bound) confirms on Testnet without hitting Soroban CPU/memory limits.
+- Contract-level: `cargo test -p escrow batch_atomicity::` (deterministic, no network/keys).
+- On-chain: a small Node harness builds each operation against the Testnet API, signs the
+  returned XDR with `@stellar/stellar-sdk`, and submits via `/stellar/send-transaction`. The
+  contract IDs and transaction hashes above are verifiable on
+  `https://stellar.expert/explorer/testnet`.


### PR DESCRIPTION
<p align="center"> <img src="https://github.com/user-attachments/assets/5b182044-dceb-41f5-acf0-da22dea7c98a" alt="CLR-S (2)"> </p>

# Pull Request | Trustless Work

## 1. Issue Link

- Closes #87

---

## 2. Brief Description of the Issue

[TEST-03] asks whether the Multi-Release V2 batch operations — `approve-milestones`,
`release-funds`, `dispute-milestones` — are **atomic**: if any index in a batch fails, no
milestone in that same call may be modified and no funds may move. A partial failure (some
milestones changed, others not, within one batch) would be a critical financial bug and is
hard to detect after the fact. This PR verifies the behavior across the six scenarios (A–F)
defined in the issue.

**Result: every scenario is atomic. No partial-failure bug was found** — confirmed both by
deterministic contract-level tests and by live Testnet runs.

---

## 3. Changes Made

- **`contracts/escrow/src/tests/batch_atomicity.rs`** — six reproducible integration tests
  (one per scenario A–F). Each deploys a fresh escrow, triggers the failure condition,
  asserts the exact `#[contracterror]`, then reads escrow state + token balances back to
  prove nothing was partially applied. Registered in `tests/mod.rs`.
- **`report/TEST-03-report.md`** — evidence report covering both the contract-level tests
  and a full live Testnet API run (on-chain tx hashes, contract IDs, receiver balance
  deltas, exact API error codes).
- No production contract code changed — this is a verification/evidence contribution.

---

## 4. Evidence After Solution

No Loom video; the evidence is the passing test suite plus on-chain transactions, shown
below (all clearly verifiable).

**Contract-level tests** — `cargo test -p escrow batch_atomicity::`:

```
running 6 tests
test tests::batch_atomicity::scenario_a_approve_out_of_range_index_is_atomic ... ok
test tests::batch_atomicity::scenario_b_release_with_unapproved_milestone_is_atomic ... ok
test tests::batch_atomicity::scenario_c_release_with_already_released_milestone_is_atomic ... ok
test tests::batch_atomicity::scenario_d_release_all_milestones_distributes_correctly ... ok
test tests::batch_atomicity::scenario_e_empty_batches_return_descriptive_errors ... ok
test tests::batch_atomicity::scenario_f_dispute_with_already_disputed_milestone_is_atomic ... ok
test result: ok. 6 passed; 0 failed   (full suite: 46 passed; 0 failed)
```

**Live Testnet API** — each scenario run end-to-end (build → sign client-side → submit):

| Scenario | API result | Atomic? |
|---|---|---|
| A — approve `[0,1,99]` | `404 ESCROW_MILESTONE_TO_APPROVE_DOES_NOT_EXIST` | ✅ M0/M1 not approved |
| B — release `[0,1,2]`, M1 unapproved | `409 ESCROW_NOT_COMPLETED` | ✅ no funds moved (deltas `0,0,0`) |
| C — release `[0,1,2]`, M0 already released | `409 ESCROW_MILESTONE_ALREADY_RELEASED` | ✅ M1/M2 untouched |
| D — release all `[0,1,2,3,4]` | `200 OK`, exact net per receiver, no resource error | ✅ |
| E — empty `[]` ×3 | `400 BAD_REQUEST` (descriptive, not silent) | ✅ no state change |
| F — dispute `[0,1]`, M0 already disputed | `409 ESCROW_MILESTONE_ALREADY_DISPUTED` | ✅ M1 not disputed |

Sample on-chain transactions (Testnet, verifiable on stellar.expert):

- Scenario D — 5-way release in a single tx: [`c4ede26a…77f946`](https://stellar.expert/explorer/testnet/tx/c4ede26a9fd2b4761ca8b4173b03164b0ff9863b4416f7504f47f2367877f946) · contract [`CC3PQRZR…GC53`](https://stellar.expert/explorer/testnet/contract/CC3PQRZRPCF2GGAJVJIKYUN3ACON7O6NHOOHWPMD7GMUPWGNB3ZXGC53)
- Scenario F — individual dispute of M0: [`ab257a4d…2734e`](https://stellar.expert/explorer/testnet/tx/ab257a4ddde1aa282a183ddb2c9d87450b1a4f56a5eb69bda2188e49d692734e)
- Scenario C — individual release of M0: [`eec90843…ac70`](https://stellar.expert/explorer/testnet/tx/eec9084301b6036b2d1767ad761e904b4018900e39bcaf33b7f9620392dcac70)

Full per-scenario detail (payloads, all tx hashes, balances, escrow state) is in
[`report/TEST-03-report.md`](report/TEST-03-report.md).

---

## 5. Important Notes

- **Branch target:** `feat/multi-release-v2` — the batch endpoints (`approve_milestones`,
  `release_funds`, `dispute_milestones` with a `Vec<u32>` of indices) live here.
- **Why atomic:** each batch op validates the entire index set first, mutates an in-memory
  copy, then commits with a single `storage.set`. The error returns before that write, so
  there is no partial-write window; Soroban's transaction rollback is a second safety net.
- **Finding (Scenario E):** empty batches are rejected at the API's request-validation layer
  (`HTTP 400 "milestoneIndexes must contain at least 1 elements"`) *before* reaching the
  contract, so the contract's own empty-batch errors (`ReleaseMilestonesEmpty` #4,
  `BatchMilestoneApproveEmpty` #9, `BatchMilestoneDisputeEmpty` #42 — reachable in the Rust
  tests) are never surfaced over the API. Still a descriptive error, never a silent no-op.
- **Reproduce the contract tests:** `cargo test -p escrow batch_atomicity::` (no network or
  keys required). The live run used native XLM on Testnet; amounts checked to the stroop.
