### PR TITLE
fix(cctp): clear stale cross-chain destination on milestone amount change

### DIFF
--- a/contracts/escrow/src/core/escrow.rs
+++ b/contracts/escrow/src/core/escrow.rs
@@ -333,6 +333,22 @@ impl EscrowManager {
                 milestone.description = desc;
             }
             if let Some(amount) = update.new_amount {
+                // A registered CrossChainDestination stores a receiver-approved
+                // `max_fee` that `set_cross_chain_destination` validated against
+                // the milestone amount at registration time (<= 10% of it).
+                // Changing the amount here would leave that `max_fee` bound to a
+                // stale amount — if the amount is reduced, the stored `max_fee`
+                // could exceed the 10% cap and let the CCTP forwarding fee eat a
+                // larger share of the payout than the invariant allows. We clear
+                // the destination (option a: simplest/safest) so the receiver
+                // must re-register it against the new amount, re-running
+                // validate_destination. Cleared unconditionally on any amount
+                // change to keep the rule trivial to reason about.
+                if amount != milestone.amount {
+                    e.storage()
+                        .persistent()
+                        .remove(&DataKey::CrossChainDestination(update.index));
+                }
                 milestone.amount = amount;
             }
             existing_escrow.milestones.set(update.index, milestone);

--- a/contracts/escrow/src/tests/cctp.rs
+++ b/contracts/escrow/src/tests/cctp.rs
@@ -7,7 +7,7 @@ use crate::modules::cctp::release::{
     release_receiver_amount_via_cctp_with_messenger,
 };
 use crate::storage::types::{
-    Dispute, Escrow, Milestone, MilestoneApprovals, Roles, Trustline,
+    Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneUpdate, Roles, Trustline,
 };
 use soroban_sdk::{
     contract, contractimpl, testutils::Address as _, token, vec, Address, Bytes, BytesN, Env,
@@ -361,6 +361,73 @@ fn receiver_can_clear_destination_to_revert_to_stellar() {
 
     let (_tw, _plat, net) = net_of(each, platform_fee);
     assert_eq!(usdc.0.balance(&f.receiver0), net);
+}
+
+/// Security regression: reducing a milestone's amount via `manage_milestones`
+/// must clear its registered CrossChainDestination so a `max_fee` validated
+/// against the old (larger) amount can't survive as a stale value exceeding the
+/// 10% cap of the new (smaller) amount. The payout then reverts to Stellar.
+#[test]
+fn reducing_milestone_amount_clears_cross_chain_destination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let usdc = create_usdc_token(&env, &admin);
+
+    let messenger = Address::from_str(&env, CCTP_TOKEN_MESSENGER_STRKEY);
+    env.register_at(&messenger, MockTokenMessenger, ());
+
+    let each: i128 = 50_000_000;
+    let platform_fee: u32 = 500;
+    let f = base_escrow(&env, &usdc.0.address, each, platform_fee);
+    let tw_address = Address::generate(&env);
+
+    let client = create_escrow_contract(&env, &f.admin).client;
+    client.initialize_escrow(&f.escrow);
+
+    // Receiver approves a max_fee at the 10% cap of the original amount.
+    let original_max_fee = each / 10;
+    client.set_cross_chain_destination(
+        &f.receiver0,
+        &0u32,
+        &6,
+        &evm_recipient(&env, 0xAB),
+        &original_max_fee,
+    );
+    assert_eq!(
+        client.get_cross_chain_destination(&0u32).max_fee,
+        original_max_fee
+    );
+
+    // Admin reduces milestone 0's amount while the contract is unfunded. The
+    // stale max_fee would now be 100% of the new amount, violating the cap.
+    let reduced: i128 = each / 10;
+    let updates = vec![
+        &env,
+        MilestoneUpdate {
+            index: 0u32,
+            new_description: None,
+            new_amount: Some(reduced),
+        },
+    ];
+    client.manage_milestones(&f.admin, &vec![&env], &updates);
+
+    // The destination must have been cleared.
+    assert_eq!(
+        client.try_get_cross_chain_destination(&0u32).err(),
+        Some(Ok(CctpError::DestinationNotSet))
+    );
+
+    // And at release the milestone 0 payout reverts to the Stellar receiver
+    // instead of burning via the messenger.
+    usdc.1.mint(&client.address, &reduced);
+    client.approve_milestones(&vec![&env, 0u32], &f.approver);
+    client.release_funds(&f.release_signer, &tw_address, &vec![&env, 0u32]);
+
+    let (_tw, _plat, net) = net_of(reduced, platform_fee);
+    assert_eq!(usdc.0.balance(&f.receiver0), net);
+    assert_eq!(usdc.0.balance(&messenger), 0);
 }
 
 #[test]


### PR DESCRIPTION
<p align="center">
  <img src="https://github.com/user-attachments/assets/5b182044-dceb-41f5-acf0-da22dea7c98a" alt="CLR-S (2)">
</p>

# Pull Request | Trustless Work

## 1. Issue Link

<!-- Provide the link to the related issue here -->

- Closes #101 - [Security] CCTP `max_fee` can become stale when a milestone amount is reduced



---

## 2. Brief Description of the Issue

<!-- Give a concise description of the issue to give context to reviewers. What problem does it solve? -->

`set_cross_chain_destination` validates that the receiver-approved `max_fee` does not exceed **10% of `milestone.amount`** at the time it is registered. However, a milestone's amount can later be **reduced** via `manage_milestones` (allowed while the contract balance is 0), and that flow did **not** re-validate or clear the already-stored `CrossChainDestination`.

The result was a stored `max_fee` that could exceed 10% of the new (smaller) milestone amount. At release time, that stale `max_fee` is used for the CCTP burn, letting the Forwarding Service fee consume a larger share of the payout than the contract's invariant intends (STRIDE: Tampering, Severity: Low).

**Reproduction:**
1. Initialize escrow, one milestone with `amount = 1000`.
2. Receiver registers a CCTP destination with `max_fee = 100` (10% of 1000).  valid.
3. With balance at 0, the admin reduces the milestone amount to `100` via `manage_milestones`.
4. The `CrossChainDestination` still holds `max_fee = 100` (= 100% of the new amount), outside the 10% invariant.

---

## 3. Changes Made

<!-- Describe the main changes and enhancements made to address the issue. List the modifications clearly and concisely. -->

- **`contracts/escrow/src/core/escrow.rs` — `manage_milestones`:** when a `milestone_updates` entry changes a milestone's amount, the milestone's `CrossChainDestination` (`DataKey::CrossChainDestination(index)`) is now **cleared** (Option **a**). This forces the receiver to re-register the destination, re-running `validate_destination` against the new amount. Verified this is the **only** code path that mutates a milestone's amount, so it is the only place that needed the fix.
- **In-code documentation:** added a comment at the clearing site explaining the invariant, the stale-`max_fee` risk, and the rationale for choosing Option (a) — cleared unconditionally on any amount change to keep the rule trivial to reason about.
- **`contracts/escrow/src/tests/cctp.rs`:** added regression test `reducing_milestone_amount_clears_cross_chain_destination` covering the issue's repro - register a destination at the 10% cap, reduce the amount via `manage_milestones`, then assert (a) the destination is cleared (`DestinationNotSet`) and (b) the release payout reverts to the Stellar receiver instead of burning via the CCTP messenger.

---

## 4. Evidence After Solution
<img width="1063" height="497" alt="test11" src="https://github.com/user-attachments/assets/54230665-1af7-435b-90d8-b754288a36b9" />


Run locally with:

```bash
cargo test -p escrow
```

---

Closes #101 
